### PR TITLE
feat(preview-lab): add Layout and Semantics inspector tab (JVM)

### DIFF
--- a/gallery/src/jvmMain/kotlin/me/tbsten/compose/preview/lab/PreviewLabApplication.jvm.kt
+++ b/gallery/src/jvmMain/kotlin/me/tbsten/compose/preview/lab/PreviewLabApplication.jvm.kt
@@ -2,6 +2,7 @@ package me.tbsten.compose.preview.lab
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
@@ -15,6 +16,7 @@ import java.util.Collections.emptyMap
 import me.tbsten.compose.preview.lab.gallery.PreviewLabGallery
 import me.tbsten.compose.preview.lab.gallery.PreviewLabGalleryState
 import me.tbsten.compose.preview.lab.gallery.PreviewListGrid
+import me.tbsten.compose.preview.lab.previewlab.LocalComposeWindow
 import me.tbsten.compose.preview.lab.previewlab.openfilehandler.OpenFileHandler
 import me.tbsten.compose.preview.lab.ui.adaptive
 
@@ -117,12 +119,16 @@ fun ApplicationScope.PreviewLabGalleryWindows(
         onPreviewKeyEvent = onPreviewKeyEvent,
         onKeyEvent = onKeyEvent,
     ) {
-        PreviewLabGallery(
-            previewList = previewList,
-            featuredFileList = featuredFileList,
-            openFileHandler = openFileHandler,
-            state = state,
-            noSelectedContents = noSelectedContents,
-        )
+        CompositionLocalProvider(
+            LocalComposeWindow provides window,
+        ) {
+            PreviewLabGallery(
+                previewList = previewList,
+                featuredFileList = featuredFileList,
+                openFileHandler = openFileHandler,
+                state = state,
+                noSelectedContents = noSelectedContents,
+            )
+        }
     }
 }

--- a/integrationTest/app/src/commonMain/kotlin/me/tbsten/compose/preview/lab/sample/ComposeMultiplatformWizardDefaultUI.kt
+++ b/integrationTest/app/src/commonMain/kotlin/me/tbsten/compose/preview/lab/sample/ComposeMultiplatformWizardDefaultUI.kt
@@ -147,7 +147,7 @@ internal fun ComposeMultiplatformWizardDefaultUI(isRotating: Boolean, onIsRotati
 @Preview
 @Composable
 private fun ComposeMultiplatformWizardDefaultUIPreview() = PreviewLab {
-    var isRotating by fieldState { BooleanField("is", false) }
+    var isRotating by fieldState { BooleanField("isRotating", false) }
 
     ComposeMultiplatformWizardDefaultUI(
         isRotating = isRotating,

--- a/preview-lab/build.gradle.kts
+++ b/preview-lab/build.gradle.kts
@@ -67,6 +67,13 @@ kotlin {
             it.get().dependsOn(otherWeb)
         }
 
+        val otherDesktop by creating {
+            dependsOn(commonMain.get())
+        }
+        listOf(androidMain, iosMain, webMain).forEach {
+            it.get().dependsOn(otherDesktop)
+        }
+
         commonMain.dependencies {
             api(projects.core)
             api(projects.ui)
@@ -135,6 +142,6 @@ publishConvention {
     artifactId = "preview-lab"
     description =
         "A component catalog library that collects and lists @Preview. \n" +
-        "By providing APIs such as Field, Event, etc., it provides not only display but also interactive preview.\n" +
-        "preview-lab provides <TODO>"
+            "By providing APIs such as Field, Event, etc., it provides not only display but also interactive preview.\n" +
+            "preview-lab provides <TODO>"
 }

--- a/preview-lab/src/commonMain/kotlin/me/tbsten/compose/preview/lab/previewlab/PreviewLab.kt
+++ b/preview-lab/src/commonMain/kotlin/me/tbsten/compose/preview/lab/previewlab/PreviewLab.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -668,7 +669,7 @@ private fun ContentSection(
                     .onPlaced {
                         state.contentRootOffsetInAppRoot =
                             it.positionInRoot().toDpOffset(density)
-                    },
+                    }.testTag("PreviewLab.content"),
             ) {
                 content(state.scope)
             }

--- a/preview-lab/src/commonMain/kotlin/me/tbsten/compose/preview/lab/previewlab/inspectorspane/InspectorTab.kt
+++ b/preview-lab/src/commonMain/kotlin/me/tbsten/compose/preview/lab/previewlab/inspectorspane/InspectorTab.kt
@@ -163,6 +163,13 @@ interface InspectorTab {
         /**
          * Default built-in tabs: Fields and Events
          */
-        val defaults: List<InspectorTab> = listOf(Fields, Events)
+        val defaults by lazy { DefaultInspectorTabs }
     }
 }
+
+internal expect val DefaultInspectorTabs: List<InspectorTab>
+
+internal val SharedDefaultInspectorTabs = listOf(
+    InspectorTab.Fields,
+    InspectorTab.Events,
+).also { println("commonMain SharedDefaultInspectorTabs") }

--- a/preview-lab/src/jvmMain/kotlin/me/tbsten/compose/preview/lab/previewlab/LocalComposeWindow.kt
+++ b/preview-lab/src/jvmMain/kotlin/me/tbsten/compose/preview/lab/previewlab/LocalComposeWindow.kt
@@ -1,0 +1,8 @@
+package me.tbsten.compose.preview.lab.previewlab
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.awt.ComposeWindow
+import me.tbsten.compose.preview.lab.InternalComposePreviewLabApi
+
+@InternalComposePreviewLabApi
+val LocalComposeWindow = staticCompositionLocalOf<ComposeWindow?> { null }

--- a/preview-lab/src/jvmMain/kotlin/me/tbsten/compose/preview/lab/previewlab/inspectorspane/InspectorTab.jvm.kt
+++ b/preview-lab/src/jvmMain/kotlin/me/tbsten/compose/preview/lab/previewlab/inspectorspane/InspectorTab.jvm.kt
@@ -1,0 +1,5 @@
+package me.tbsten.compose.preview.lab.previewlab.inspectorspane
+
+internal actual val DefaultInspectorTabs: List<InspectorTab> = SharedDefaultInspectorTabs + listOf(
+    LayoutAndSemanticsTab,
+).also { println("jvm DefaultInspectorTabs") }

--- a/preview-lab/src/jvmMain/kotlin/me/tbsten/compose/preview/lab/previewlab/inspectorspane/LayoutAndSemanticsTab.kt
+++ b/preview-lab/src/jvmMain/kotlin/me/tbsten/compose/preview/lab/previewlab/inspectorspane/LayoutAndSemanticsTab.kt
@@ -1,0 +1,204 @@
+@file:OptIn(ExperimentalComposeUiApi::class)
+
+package me.tbsten.compose.preview.lab.previewlab.inspectorspane
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsOwner
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.unit.dp
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+import me.tbsten.compose.preview.lab.ExperimentalComposePreviewLabApi
+import me.tbsten.compose.preview.lab.previewlab.LocalComposeWindow
+import me.tbsten.compose.preview.lab.ui.PreviewLabTheme
+import me.tbsten.compose.preview.lab.ui.components.CommonIconButton
+import me.tbsten.compose.preview.lab.ui.components.Divider
+import me.tbsten.compose.preview.lab.ui.components.Switch
+import me.tbsten.compose.preview.lab.ui.components.Text
+import me.tbsten.compose.preview.lab.ui.generated.resources.PreviewLabUiRes
+import me.tbsten.compose.preview.lab.ui.generated.resources.icon_refresh
+import org.jetbrains.compose.resources.painterResource
+
+@ExperimentalComposePreviewLabApi
+data object LayoutAndSemanticsTab : InspectorTab {
+    override val title: String = "Layout and Semantics"
+
+    @Composable
+    override fun InspectorTab.ContentContext.Content() = SelectionContainer {
+        var useUnmerged by remember { mutableStateOf(false) }
+
+        val semanticsOwner =
+            LocalComposeWindow.current
+                ?.semanticsOwners
+                ?.firstOrNull()
+                ?: run {
+                    Text("Not supported.")
+                    return@SelectionContainer
+                }
+
+        var _previewLabContent by remember(semanticsOwner, useUnmerged) {
+            mutableStateOf(getContentSemanticsNodeTree(semanticsOwner, useUnmerged))
+        }.also { state ->
+            LaunchedEffect(state) {
+                while (true) {
+                    state.value = getContentSemanticsNodeTree(semanticsOwner, useUnmerged)
+                    delay(0.2.seconds)
+                }
+            }
+        }
+        val previewLabContent = _previewLabContent ?: run {
+            Text("Not supported: Not found PreviewLab.content")
+            return@SelectionContainer
+        }
+
+        LazyColumn {
+            stickyHeader {
+                Header(
+                    onRefresh = { _previewLabContent = getContentSemanticsNodeTree(semanticsOwner, useUnmerged) },
+                )
+            }
+
+            item {
+                UseUnmergedSwitchRow(
+                    useUnmerged = useUnmerged,
+                    onChange = { useUnmerged = it },
+                )
+            }
+
+            item {
+                SemanticsNodeView(
+                    node = previewLabContent,
+                    isRoot = true,
+                    currentDeps = 0,
+                    maxDeps = 5,
+                )
+            }
+        }
+    }
+}
+
+private fun getContentSemanticsNodeTree(
+    semanticsOwner: SemanticsOwner,
+    useUnmerged: Boolean,
+): SemanticsNode? {
+    val root =
+        semanticsOwner
+            .run { if (useUnmerged) unmergedRootSemanticsNode else rootSemanticsNode }
+
+    return root
+        .find { it.config.getOrNull(SemanticsProperties.TestTag) == "PreviewLab.content" }
+}
+
+fun SemanticsNode.find(includeSelf: Boolean = true, block: (SemanticsNode) -> Boolean): SemanticsNode? {
+    if (includeSelf && block(this)) return this
+    return this.children.firstNotNullOfOrNull { it.find(true, block) }
+}
+
+@Composable
+private fun Header(
+    onRefresh: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth(),
+    ) {
+        Spacer(Modifier.weight(1f))
+        CommonIconButton(
+            painter = painterResource(PreviewLabUiRes.drawable.icon_refresh),
+            contentDescription = "Refresh",
+            onClick = onRefresh,
+        )
+    }
+}
+
+@Composable
+private fun UseUnmergedSwitchRow(
+    useUnmerged: Boolean,
+    onChange: (Boolean) -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        modifier = Modifier
+            .clickable { onChange(!useUnmerged) }
+            .padding(8.dp)
+            .fillMaxWidth(),
+    ) {
+        Switch(
+            checked = useUnmerged,
+            onCheckedChange = onChange,
+        )
+
+        Text("use unmerged", style = PreviewLabTheme.typography.label1)
+    }
+}
+
+@Composable
+private fun SemanticsNodeView(
+    node: SemanticsNode,
+    isRoot: Boolean,
+    currentDeps: Int,
+    maxDeps: Int,
+) {
+    if (maxDeps < currentDeps) return
+
+    val isRoot = isRoot || node.isRoot
+
+    Column {
+        Row {
+            val text: String =
+                "(Root)".takeIf { isRoot }
+                // Fallback
+                // config.Text
+                    ?: node.config.getOrNull(SemanticsProperties.Text)?.joinToString(", ")
+                    // config.InputText
+                    ?: node.config.getOrNull(SemanticsProperties.InputText)?.toString()
+                    // (config.TestTag)
+                    ?: node.config.getOrNull(SemanticsProperties.TestTag)?.let { "(TestTag=${it})" }
+                    // (config.Role)
+                    ?: node.config.getOrNull(SemanticsProperties.Role)?.let { "(Role=${it})" }
+                    // (first 30 char of config.ContentDescription)
+                    ?: node.config.getOrNull(SemanticsProperties.ContentDescription)
+                        ?.joinToString(", ")
+                        ?.let { cd -> "${cd.take(30)}${"...".takeIf { cd.length > 30 }}" }
+                        ?.let { "(ContentDescription=${it})" }
+                    // top,left widthxheight
+                    ?: node.boundsInRoot.let { "size=${it.top},${it.left} ${it.width}x${it.height}" }
+
+            Text(text)
+        }
+
+        Divider(Modifier.padding(vertical = 12.dp))
+
+        Column(Modifier.padding(start = 20.dp)) {
+            node.children.forEach { child ->
+
+                SemanticsNodeView(
+                    node = child,
+                    isRoot = false,
+                    currentDeps = currentDeps + 1,
+                    maxDeps = maxDeps,
+                )
+            }
+        }
+    }
+}

--- a/preview-lab/src/otherDesktop/kotlin/me/tbsten/compose/preview/lab/previewlab/inspectorspane/InspectorTab.otherDesktop.kt
+++ b/preview-lab/src/otherDesktop/kotlin/me/tbsten/compose/preview/lab/previewlab/inspectorspane/InspectorTab.otherDesktop.kt
@@ -1,0 +1,3 @@
+package me.tbsten.compose.preview.lab.previewlab.inspectorspane
+
+internal actual val DefaultInspectorTabs: List<InspectorTab> = SharedDefaultInspectorTabs


### PR DESCRIPTION
## Summary

- JVM（デスクトップ）向けに Layout and Semantics インスペクタータブを追加
- ComposeのセマンティクスツリーをUIで確認できる機能
- `LocalComposeWindow` CompositionLocal を追加し、ComposeWindowへのアクセスを提供

## Changes

- `LayoutAndSemanticsTab`: セマンティクスノードをツリー表示するタブ
- `DefaultInspectorTabs`: プラットフォーム別に `expect/actual` で切り替え
- `otherDesktop` ソースセット追加（Android/iOS/Web向けフォールバック）

## Test plan

- [ ] JVMでPreviewLabGalleryを起動し、Layout and Semanticsタブが表示されることを確認
- [ ] セマンティクスツリーが正しく表示されることを確認
- [ ] Android/iOS/Webではタブが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)