### PR TITLE
[nits] fix: badge links

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -30,12 +30,8 @@ Compose Multiplatformに対応しています。
 
 ## セットアップ
 
-<a href="https://central.sonatype.com/artifact/me.tbsten.compose.preview.lab/core">
-<img src="https://img.shields.io/maven-central/v/me.tbsten.compose.preview.lab/core?label=compose-preview-lab" alt="Maven Central"/>
-</a>
-<a href="https://central.sonatype.com/artifact/com.google.devtools.ksp/symbol-processing-api">
-<img src="https://img.shields.io/maven-central/v/com.google.devtools.ksp/symbol-processing-api?label=ksp" alt="KSP Version"/>
-</a>
+<a href="https://central.sonatype.com/artifact/me.tbsten.compose.preview.lab/core"><img src="https://img.shields.io/maven-central/v/me.tbsten.compose.preview.lab/core?label=compose-preview-lab" alt="Maven Central"/></a>
+<a href="https://central.sonatype.com/artifact/com.google.devtools.ksp/symbol-processing-api"><img src="https://img.shields.io/maven-central/v/com.google.devtools.ksp/symbol-processing-api?label=ksp" alt="KSP Version"/></a>
 
 <details>
 <summary> [推奨] Compose Multiplatformプロジェクト - Starterを使用した簡単セットアップ</summary>


### PR DESCRIPTION
|before|after|
|-|-|
|<img src="https://github.com/user-attachments/assets/5fb90f97-241d-4031-8d97-f0e400c0ed5d" alt="" width="240">|<img src="https://github.com/user-attachments/assets/fad3fa70-6c50-41b7-aba0-5c525341f3c0" alt="" width="240">|

`<a>` と `<img>` の間に改行があるとアンスコがレンダリングされてしまうみたいです