### PR TITLE
feat(gradle-plugin): inject -Xcompiler-plugin-order for Kotlin 2.3+

### DIFF
--- a/gradle-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/ComposePreviewLabGradlePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/ComposePreviewLabGradlePlugin.kt
@@ -13,7 +13,9 @@ class ComposePreviewLabGradlePlugin : Plugin<Project> {
         pluginManager.apply(ComposePreviewLabSubplugin::class.java)
         val extension = extensions.getByType(ComposePreviewLabExtension::class.java)
         configureFeaturedFiles(extension = extension)
-        validatePluginOrder()
+        if (!supportsCompilerPluginOrder()) {
+            validatePluginOrder()
+        }
     }
 
     /**
@@ -29,7 +31,8 @@ class ComposePreviewLabGradlePlugin : Plugin<Project> {
             throw GradleException(
                 "Compose Preview Lab plugin (me.tbsten.compose.preview.lab) must be applied " +
                     "BEFORE the Compose Compiler plugin ($composeCompilerPluginId) in build.gradle.kts. " +
-                    "The current order may cause runtime errors with @Composable lambdas.",
+                    "The current order may cause runtime errors with @Composable lambdas. " +
+                    "Upgrading to Kotlin 2.3 or later removes this restriction automatically.",
             )
         }
     }

--- a/gradle-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/ComposePreviewLabSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/ComposePreviewLabSubplugin.kt
@@ -26,6 +26,15 @@ class ComposePreviewLabSubplugin : KotlinCompilerPluginSupportPlugin {
 
     override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
         val project = kotlinCompilation.target.project
+
+        if (project.supportsCompilerPluginOrder()) {
+            kotlinCompilation.compileTaskProvider.configure {
+                compilerOptions.freeCompilerArgs.add(
+                    "-Xcompiler-plugin-order=$PreviewLabCompilerPluginId>$ComposeCompilerPluginId",
+                )
+            }
+        }
+
         val extension = project.extensions.getByType<ComposePreviewLabExtension>()
 
         return project.provider {

--- a/gradle-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/ComposePreviewLabSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/ComposePreviewLabSubplugin.kt
@@ -14,7 +14,7 @@ class ComposePreviewLabSubplugin : KotlinCompilerPluginSupportPlugin {
     override fun apply(target: Project) {
     }
 
-    override fun getCompilerPluginId(): String = "me.tbsten.compose.preview.lab.compiler"
+    override fun getCompilerPluginId(): String = PreviewLabCompilerPluginId
 
     override fun getPluginArtifact(): SubpluginArtifact = SubpluginArtifact(
         groupId = PluginGroupId,

--- a/gradle-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/PluginOrder.kt
+++ b/gradle-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/PluginOrder.kt
@@ -24,12 +24,12 @@ internal data class KotlinSemVer(val major: Int, val minor: Int, val patch: Int)
     }
 }
 
-internal val KOTLIN_2_3_0 = KotlinSemVer(2, 3, 0)
+private val kotlin230 = KotlinSemVer(2, 3, 0)
 
 internal fun Project.detectedKotlinVersion(): KotlinSemVer? =
     runCatching { getKotlinPluginVersion() }.getOrNull()?.let(KotlinSemVer::parse)
 
 internal fun Project.supportsCompilerPluginOrder(): Boolean {
     val version = detectedKotlinVersion() ?: return false
-    return version >= KOTLIN_2_3_0
+    return version >= kotlin230
 }

--- a/gradle-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/PluginOrder.kt
+++ b/gradle-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/PluginOrder.kt
@@ -17,9 +17,15 @@ internal data class KotlinSemVer(val major: Int, val minor: Int, val patch: Int)
 
     companion object {
         fun parse(raw: String): KotlinSemVer? {
-            val parts = raw.substringBefore('-').split('.').mapNotNull(String::toIntOrNull)
+            val coreVersion = raw.substringBefore('-').substringBefore('+')
+            val parts = coreVersion.split('.')
             if (parts.size < 2) return null
-            return KotlinSemVer(parts[0], parts[1], parts.getOrElse(2) { 0 })
+
+            val major = parts[0].toIntOrNull() ?: return null
+            val minor = parts[1].toIntOrNull() ?: return null
+            val patch = parts.getOrNull(2)?.toIntOrNull() ?: 0
+
+            return KotlinSemVer(major, minor, patch)
         }
     }
 }

--- a/gradle-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/PluginOrder.kt
+++ b/gradle-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/PluginOrder.kt
@@ -1,0 +1,35 @@
+package me.tbsten.compose.preview.lab
+
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
+
+internal const val PreviewLabCompilerPluginId = "me.tbsten.compose.preview.lab.compiler"
+internal const val ComposeCompilerPluginId = "androidx.compose.compiler.plugins.kotlin"
+
+internal data class KotlinSemVer(val major: Int, val minor: Int, val patch: Int) : Comparable<KotlinSemVer> {
+    override fun compareTo(other: KotlinSemVer) = compareValuesBy(
+        this,
+        other,
+        KotlinSemVer::major,
+        KotlinSemVer::minor,
+        KotlinSemVer::patch,
+    )
+
+    companion object {
+        fun parse(raw: String): KotlinSemVer? {
+            val parts = raw.substringBefore('-').split('.').mapNotNull(String::toIntOrNull)
+            if (parts.size < 2) return null
+            return KotlinSemVer(parts[0], parts[1], parts.getOrElse(2) { 0 })
+        }
+    }
+}
+
+internal val KOTLIN_2_3_0 = KotlinSemVer(2, 3, 0)
+
+internal fun Project.detectedKotlinVersion(): KotlinSemVer? =
+    runCatching { getKotlinPluginVersion() }.getOrNull()?.let(KotlinSemVer::parse)
+
+internal fun Project.supportsCompilerPluginOrder(): Boolean {
+    val version = detectedKotlinVersion() ?: return false
+    return version >= KOTLIN_2_3_0
+}

--- a/integrationTest/settings.gradle.kts
+++ b/integrationTest/settings.gradle.kts
@@ -43,3 +43,4 @@ plugins {
 includeBuild("../")
 include(":app")
 include(":uiLib")
+include(":uiLibReversed")

--- a/integrationTest/uiLib/build.gradle.kts
+++ b/integrationTest/uiLib/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
-    // NOTE: "me.tbsten.compose.preview.lab" must be applied BEFORE composeCompiler
     id("me.tbsten.compose.preview.lab")
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)

--- a/integrationTest/uiLibReversed/build.gradle.kts
+++ b/integrationTest/uiLibReversed/build.gradle.kts
@@ -1,0 +1,41 @@
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
+
+// Reversed plugin order fixture: composeCompiler is applied BEFORE me.tbsten.compose.preview.lab.
+// On Kotlin 2.3+, -Xcompiler-plugin-order injected by the gradle-plugin ensures correct IR ordering.
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.composeCompiler)
+    id("me.tbsten.compose.preview.lab")
+    alias(libs.plugins.composeMultiplatform)
+}
+
+kotlin {
+    jvmToolchain(17)
+
+    androidTarget {
+        @Suppress("OPT_IN_USAGE")
+        instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
+    }
+
+    jvm()
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.composeRuntime)
+            implementation(libs.composeFoundation)
+            implementation(libs.composeMaterial3)
+            implementation(libs.composeUiToolingPreview)
+            implementation("me.tbsten.compose.preview.lab:starter:${libs.versions.composePreviewLab.get()}")
+        }
+    }
+}
+
+android {
+    namespace = "me.tbsten.compose.preview.lab.sample.uiLibReversed"
+    compileSdk = 36
+}
+
+composePreviewLab {
+    publicPreviewList = true
+}

--- a/integrationTest/uiLibReversed/src/commonMain/kotlin/me/tbsten/compose/preview/lab/sample/libreversed/MyButton.kt
+++ b/integrationTest/uiLibReversed/src/commonMain/kotlin/me/tbsten/compose/preview/lab/sample/libreversed/MyButton.kt
@@ -1,0 +1,24 @@
+package me.tbsten.compose.preview.lab.sample.libreversed
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import me.tbsten.compose.preview.lab.field.StringField
+import me.tbsten.compose.preview.lab.previewlab.PreviewLab
+
+@Composable
+fun MyButton(label: String, onClick: () -> Unit) {
+    Button(onClick = onClick) {
+        Text(label)
+    }
+}
+
+@Preview
+@Composable
+fun MyButtonPreview() = PreviewLab {
+    MyButton(
+        label = fieldValue { StringField("Label", "Click me") },
+        onClick = {},
+    )
+}


### PR DESCRIPTION
## Summary

- Automatically inject `-Xcompiler-plugin-order=me.tbsten.compose.preview.lab.compiler>androidx.compose.compiler.plugins.kotlin` on Kotlin 2.3+
- Users no longer need to apply Compose Preview Lab before Compose Compiler plugin
- `validatePluginOrder()` preserved for Kotlin 2.2.x and below
- Resolved UX constraint without breaking backward compatibility

## Changes

### New Files
- **PluginOrder.kt**: `KotlinSemVer` parser, `detectedKotlinVersion()`, `supportsCompilerPluginOrder()` utilities
- **integrationTest/uiLibReversed/**: Fixture with reversed plugin order (Compose Compiler → Preview Lab) to verify -Xcompiler-plugin-order works correctly

### Modified Files
- **ComposePreviewLabSubplugin.kt**: Inject `-Xcompiler-plugin-order` flag in `applyToCompilation()` when Kotlin >= 2.3.0
- **ComposePreviewLabGradlePlugin.kt**: 
  - Call `validatePluginOrder()` only when `!supportsCompilerPluginOrder()` 
  - Add hint message to error output suggesting Kotlin 2.3 upgrade
- **integrationTest/settings.gradle.kts**: Include uiLibReversed module
- **integrationTest/uiLib/build.gradle.kts**: Remove obsolete NOTE comment

## Test plan

- [x] ktlintCheck passes (`./gradlew ktlintCheck`)
- [x] jvmTest passes (`./gradlew jvmTest`)
- [x] uiLibReversed compiles successfully with reversed plugin order
- [x] uiLib continues to work with correct plugin order (no regression)
- [x] Integration tests pass (`./gradlew :app:jvmTest`)
- [x] Kotlin version detection works correctly for 2.3+

🤖 Generated with [Claude Code](https://claude.com/claude-code)