### PR TITLE
test(compiler-plugin): cover KLIB cross-module aggregation via kctfork JS_IR (bug-017 step 5)

### DIFF
--- a/compiler-plugin/build.gradle.kts
+++ b/compiler-plugin/build.gradle.kts
@@ -102,12 +102,39 @@ listOf("testCompileClasspath", "testRuntimeClasspath").forEach { name ->
     }
 }
 
+// Resolvable configuration that pulls `kotlin-stdlib-js` as a `.klib` artifact, bypassing
+// the Kotlin Multiplatform variant resolution rules that would reject it on a JVM consumer.
+// kctfork's `KotlinJsCompilation` needs this to feed stage-1 KLIBs through `-libraries`.
+val kotlinStdlibJsKlib by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+dependencies {
+    add(kotlinStdlibJsKlib.name, "org.jetbrains.kotlin:kotlin-stdlib-js:$testKotlinVersion@klib")
+}
+
+// Configuration-cache compatible argument provider for the kotlin-stdlib-js KLIB path.
+// Captures only the FileCollection (declared as @Classpath input) so the script object
+// reference does not get serialized.
+abstract class StdlibJsKlibArgumentProvider : CommandLineArgumentProvider {
+    @get:org.gradle.api.tasks.Classpath
+    abstract val klibFiles: ConfigurableFileCollection
+
+    override fun asArguments(): List<String> = listOf("-Dtest.kotlin.stdlib.js.klib=${klibFiles.singleFile.absolutePath}")
+}
+
 tasks.withType<Test> {
     useJUnitPlatform()
     // Pass testKotlinVersion to tests so CompilerPluginTestBase can set languageVersion
     // accordingly. In Kotlin 2.1.x, FirIncompatibleClassExpressionChecker crashes when
     // languageVersion="2.0" is used with a 2.1.x compiler (source must not be null).
     systemProperty("test.kotlin.version", testKotlinVersion)
+    // Surface kotlin-stdlib-js KLIB to the JS test base so it can wire `args.libraries`.
+    jvmArgumentProviders.add(
+        objects.newInstance(StdlibJsKlibArgumentProvider::class).apply {
+            klibFiles.from(kotlinStdlibJsKlib)
+        },
+    )
     // kctfork bundles a kotlin-compiler-embeddable that cannot parse Java 26 version
     // strings, so the test JVM has to run on Java 21.
     javaLauncher.set(

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/CompilerPluginJsTestBase.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/CompilerPluginJsTestBase.kt
@@ -28,6 +28,15 @@ open class CompilerPluginJsTestBase {
 
     private val testKotlinVersion: String = System.getProperty("test.kotlin.version") ?: "2.3.21"
     private val testLanguageVersion: String = testKotlinVersion.split(".").take(2).joinToString(".")
+
+    // Mirror `CompilerPluginTestBase.needsCompatibilityFlags`. The plugin / test classes are
+    // compiled against the baseline Kotlin (2.3.x), so when the smoke-test runner swaps in an
+    // older `kotlin-compiler-embeddable` (e.g. `-Ptest.kotlin=2.1.20`) the FIR
+    // `FirIncompatibleClassExpressionChecker` rejects the metadata as "Incompatible classes were
+    // found in dependencies". The skip-check flags suppress that. JS-side compilation uses the
+    // same `parseCommandLineArguments` path so the flags work identically here.
+    private val needsCompatibilityFlags: Boolean = testKotlinVersion.startsWith("2.1")
+
     private val stdlibJsKlib: java.io.File = System.getProperty("test.kotlin.stdlib.js.klib")
         ?.let { java.io.File(it) }
         ?: error(
@@ -110,11 +119,24 @@ open class CompilerPluginJsTestBase {
         this.languageVersion = testLanguageVersion
         this.kotlinStdLibJsJar = stdlibJsKlib
 
+        val extraKotlincArgs = mutableListOf<String>()
         if (extraLibraries.isNotEmpty()) {
             // Override `args.libraries` set inside jsArgs() — kctfork's parseCommandLineArguments
             // call runs after, so this takes precedence.
-            val combined = (listOf(stdlibJsKlib) + extraLibraries).joinToString(":") { it.absolutePath }
-            this.kotlincArguments = this.kotlincArguments + listOf("-libraries", combined)
+            //
+            // Use `File.pathSeparator` (`:` on Unix, `;` on Windows) to keep the test runnable
+            // on Windows CI runners; a hard-coded `:` would treat `C:\path1;C:\path2` as a single
+            // malformed entry.
+            val combined = (listOf(stdlibJsKlib) + extraLibraries).joinToString(java.io.File.pathSeparator) {
+                it.absolutePath
+            }
+            extraKotlincArgs += listOf("-libraries", combined)
+        }
+        if (needsCompatibilityFlags) {
+            extraKotlincArgs += listOf("-Xskip-prerelease-check", "-Xskip-metadata-version-check")
+        }
+        if (extraKotlincArgs.isNotEmpty()) {
+            this.kotlincArguments = this.kotlincArguments + extraKotlincArgs
         }
     }.compile()
 

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/CompilerPluginJsTestBase.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/CompilerPluginJsTestBase.kt
@@ -1,0 +1,161 @@
+package me.tbsten.compose.preview.lab.compiler
+
+import com.tschuchort.compiletesting.JsCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.KotlinJsCompilation
+import com.tschuchort.compiletesting.PluginOption
+import com.tschuchort.compiletesting.SourceFile
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+
+/**
+ * JS_IR 版のテストヘルパー。`CompilerPluginTestBase` の JS counterpart。
+ *
+ * KLIB IdSignature 衝突 / cross-module marker class discovery が JS_IR backend で
+ * 正しく動くことを検証するテスト用。
+ *
+ * **JVM 版との差分**:
+ * - `inheritClassPath` は JS_IR では classpath だけ参照され、`-libraries` (KLIB) には
+ *   伝わらない。代わりにスタブを毎モジュールでインライン source として積む。
+ * - 依存モジュール参照は `kotlincArguments = listOf("-libraries", "<klib1>:<klib2>")` で渡す。
+ *   `KotlinJsCompilation.jsArgs()` は `args.libraries = stdlib` を設定するが、
+ *   `parseCommandLineArguments(kotlincArguments, args)` がその後に走るので上書きできる。
+ */
+@OptIn(ExperimentalCompilerApi::class)
+open class CompilerPluginJsTestBase {
+
+    private val moduleNameCounter = java.util.concurrent.atomic.AtomicInteger(0)
+
+    private val testKotlinVersion: String = System.getProperty("test.kotlin.version") ?: "2.3.21"
+    private val testLanguageVersion: String = testKotlinVersion.split(".").take(2).joinToString(".")
+    private val stdlibJsKlib: java.io.File = System.getProperty("test.kotlin.stdlib.js.klib")
+        ?.let { java.io.File(it) }
+        ?: error(
+            "test.kotlin.stdlib.js.klib system property is not set. " +
+                "Set it to the path of kotlin-stdlib-js-<version>.klib via the test task config.",
+        )
+
+    private val previewAnnotationStubs = listOf(
+        SourceFile.kotlin(
+            "CmpPreview.kt",
+            """
+            package org.jetbrains.compose.ui.tooling.preview
+            annotation class Preview
+            """,
+        ),
+        SourceFile.kotlin(
+            "AndroidPreview.kt",
+            """
+            package androidx.compose.ui.tooling.preview
+            annotation class Preview
+            """,
+        ),
+    )
+
+    private val collectPreviewsStubs = listOf(
+        SourceFile.kotlin(
+            "CollectPreviewsStubs.kt",
+            """
+            package me.tbsten.compose.preview.lab
+
+            class CollectedPreview(
+                val id: String,
+                val displayName: String,
+                val filePath: String,
+                val startLineNumber: Int,
+                val endLineNumber: Int,
+                val code: String,
+                val kdoc: String?,
+                val content: () -> Unit,
+            )
+
+            class PreviewExport(private val delegate: Lazy<List<CollectedPreview>>) {
+                operator fun getValue(thisRef: Any?, property: kotlin.reflect.KProperty<*>): List<CollectedPreview> =
+                    delegate.value
+            }
+
+            fun collectModulePreviews(): PreviewExport = PreviewExport(lazy { emptyList() })
+            fun collectAllModulePreviews(): PreviewExport = PreviewExport(lazy { emptyList() })
+            fun distinctPreviewsById(previews: List<CollectedPreview>): List<CollectedPreview> =
+                previews.distinctBy { it.id }
+            """,
+        ),
+    )
+
+    /**
+     * JS_IR `.klib` 出力を 1 モジュール分作る。
+     *
+     * - [extraLibraries] は `-libraries` に追加される `.klib` パス (Stage1 出力など)
+     * - `previewAnnotationStubs` / `collectPreviewsStubs` は毎呼び出しでインライン化されるため、
+     *   2 段ビルド時は依存側 KLIB と app 側 KLIB の両方に同じ stub class が含まれる。これは
+     *   `IdSignature` レベルでは衝突しないが、preview lab plugin が依存解決時に自モジュールを
+     *   除外するロジック (`IR_EXTERNAL_DECLARATION_STUB`) によって正しく扱われる。
+     */
+    fun compileJs(
+        vararg sources: SourceFile,
+        pluginRegistrars: List<CompilerPluginRegistrar> = listOf(ComposePreviewLabCompilerPluginRegistrar()),
+        pluginOptions: List<PluginOption> = emptyList(),
+        extraLibraries: List<java.io.File> = emptyList(),
+        moduleName: String? = null,
+    ): JsCompilationResult = KotlinJsCompilation().apply {
+        this.sources = previewAnnotationStubs + collectPreviewsStubs + sources.toList()
+        this.compilerPluginRegistrars = pluginRegistrars
+        this.commandLineProcessors = listOf(ComposePreviewLabCommandLineProcessor())
+        this.pluginOptions = pluginOptions
+        this.irProduceKlibDir = true
+        this.irProduceJs = false
+        val resolvedModuleName = moduleName ?: "preview-lab-js-test-${moduleNameCounter.incrementAndGet()}"
+        this.moduleName = resolvedModuleName
+        this.irModuleName = resolvedModuleName
+        this.languageVersion = testLanguageVersion
+        this.kotlinStdLibJsJar = stdlibJsKlib
+
+        if (extraLibraries.isNotEmpty()) {
+            // Override `args.libraries` set inside jsArgs() — kctfork's parseCommandLineArguments
+            // call runs after, so this takes precedence.
+            val combined = (listOf(stdlibJsKlib) + extraLibraries).joinToString(":") { it.absolutePath }
+            this.kotlincArguments = this.kotlincArguments + listOf("-libraries", combined)
+        }
+    }.compile()
+
+    fun collectModulePreviewsEntry(propertyName: String = "previews"): SourceFile = SourceFile.kotlin(
+        "Entry.kt",
+        """
+        package test.entry
+
+        import me.tbsten.compose.preview.lab.collectModulePreviews
+
+        val $propertyName by collectModulePreviews()
+        """,
+    )
+
+    fun collectAllModulePreviewsEntry(propertyName: String = "allPreviews"): SourceFile = SourceFile.kotlin(
+        "Entry.kt",
+        """
+        package test.entry
+
+        import me.tbsten.compose.preview.lab.collectAllModulePreviews
+
+        val $propertyName by collectAllModulePreviews()
+        """,
+    )
+}
+
+/**
+ * 出力 `.klib` ファイルを返す。`KotlinJsCompilation.outputDir` 配下に
+ * `<moduleName>.klib` (or unpacked dir) が生成される。
+ */
+internal fun JsCompilationResult.klibFiles(): List<java.io.File> {
+    val outputDir = this.outputDirectory
+    if (!outputDir.exists()) return emptyList()
+    val klibs = outputDir.walkTopDown().filter { it.isFile && it.extension == "klib" }.toList()
+    if (klibs.isNotEmpty()) return klibs
+    // `irProduceKlibDir = true` produces an unpacked klib directory whose root is the moduleName.
+    return outputDir.listFiles { f -> f.isDirectory }?.toList() ?: emptyList()
+}
+
+internal fun JsCompilationResult.assertOk() {
+    if (this.exitCode != KotlinCompilation.ExitCode.OK) {
+        error("JS compilation failed with ${this.exitCode}:\n${this.messages}")
+    }
+}

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/CrossModuleAggregationKlibTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/CrossModuleAggregationKlibTest.kt
@@ -125,5 +125,94 @@ class CrossModuleAggregationKlibTest :
                 )
                 app.assertOk()
             }
+
+            test("E-2: 同名 collectModulePreviews property を持つ依存 2 つでも IdSignature 衝突しない") {
+                // 両モジュールが同じプロパティ名 `sharedPreviews` を持つ。旧 IR-based hint scheme では
+                // `previewLabExport(PreviewExport)` の IdSignature が両モジュールで一致して link 失敗するが、
+                // 新 FIR-based path では module-name-hash で marker class を unique 化しているので両方 link 成功する。
+                val lib1 = base.compileJs(
+                    SourceFile.kotlin(
+                        "Lib1.kt",
+                        """
+                    package lib1
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun Lib1Preview() {}
+
+                    val sharedPreviews by me.tbsten.compose.preview.lab.collectModulePreviews()
+                    """,
+                    ),
+                    moduleName = "preview-lab-js-collide-lib1",
+                )
+                lib1.assertOk()
+
+                val lib2 = base.compileJs(
+                    SourceFile.kotlin(
+                        "Lib2.kt",
+                        """
+                    package lib2
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun Lib2Preview() {}
+
+                    val sharedPreviews by me.tbsten.compose.preview.lab.collectModulePreviews()
+                    """,
+                    ),
+                    moduleName = "preview-lab-js-collide-lib2",
+                )
+                lib2.assertOk()
+
+                val app = base.compileJs(
+                    SourceFile.kotlin(
+                        "App.kt",
+                        """
+                    package app
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun AppPreview() {}
+                    """,
+                    ),
+                    base.collectAllModulePreviewsEntry("appPreviews"),
+                    extraLibraries = lib1.klibFiles() + lib2.klibFiles(),
+                    moduleName = "preview-lab-js-collide-app",
+                )
+                app.assertOk()
+            }
+
+            test("E-4: @Preview を持たない依存モジュールが含まれていても link が壊れない") {
+                // empty な依存 KLIB (preview / property どちらも無し)。FIR generator は依然として
+                // marker + hint を出すので、auto-provider が空リストを返す形で生成される必要がある。
+                // (P1 fix を入れる前は previews.isEmpty() で provider 生成を skip していたため、
+                // 下流の `referenceFunctions` が空になり aggregation 自体は動くが、provider 不在の
+                // hint が残る奇妙な状態になっていた。)
+                val emptyLib = base.compileJs(
+                    SourceFile.kotlin(
+                        "EmptyLib.kt",
+                        """
+                    package emptylib
+
+                    fun nonPreviewFunction(): Int = 42
+                    """,
+                    ),
+                    moduleName = "preview-lab-js-empty-lib",
+                )
+                emptyLib.assertOk()
+
+                val app = base.compileJs(
+                    SourceFile.kotlin(
+                        "App.kt",
+                        """
+                    package app
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun AppPreview() {}
+                    """,
+                    ),
+                    base.collectAllModulePreviewsEntry("appPreviews"),
+                    extraLibraries = emptyLib.klibFiles(),
+                    moduleName = "preview-lab-js-empty-app",
+                )
+                app.assertOk()
+            }
         },
     )

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/CrossModuleAggregationKlibTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/CrossModuleAggregationKlibTest.kt
@@ -1,0 +1,129 @@
+package me.tbsten.compose.preview.lab.compiler.feature
+
+import com.tschuchort.compiletesting.SourceFile
+import io.kotest.core.spec.style.FunSpec
+import me.tbsten.compose.preview.lab.compiler.CompilerPluginJsTestBase
+import me.tbsten.compose.preview.lab.compiler.assertOk
+import me.tbsten.compose.preview.lab.compiler.klibFiles
+
+/**
+ * KLIB IdSignature 衝突回避と marker class ベースの cross-module discovery が
+ * JS_IR backend で正しく機能することを検証する。
+ *
+ * JVM 版 (`CrossModuleAggregationTest`) は class loader 経由の linking のみ検証し、
+ * KLIB の `IdSignature` collision 回避ロジック (FIR で per-module marker class を生成)
+ * を直接 exercise しない。本テストは 2 段 JS_IR compile で KLIB linking を実際に走らせ、
+ * marker class 命名が module 跨ぎで unique であることを担保する。
+ */
+class CrossModuleAggregationKlibTest :
+    FunSpec(
+        {
+            val base = CompilerPluginJsTestBase()
+
+            test("@Preview のみの単一モジュールが JS_IR backend で KLIB を生成できる") {
+                val result = base.compileJs(
+                    SourceFile.kotlin(
+                        "Lib.kt",
+                        """
+                    package uilib
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun UiLibPreview1() {}
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun UiLibPreview2() {}
+                    """,
+                    ),
+                )
+                result.assertOk()
+            }
+
+            test("依存 KLIB 2 つを含む app の JS_IR compile が IdSignature 衝突なく成功する") {
+                // Stage 1a: uiLib1 の KLIB
+                val lib1 = base.compileJs(
+                    SourceFile.kotlin(
+                        "UiLib1.kt",
+                        """
+                    package uilib1
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun UiLib1Preview1() {}
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun UiLib1Preview2() {}
+                    """,
+                    ),
+                    moduleName = "preview-lab-js-uilib1",
+                )
+                lib1.assertOk()
+
+                // Stage 1b: uiLib2 の KLIB
+                val lib2 = base.compileJs(
+                    SourceFile.kotlin(
+                        "UiLib2.kt",
+                        """
+                    package uilib2
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun UiLib2Preview() {}
+                    """,
+                    ),
+                    moduleName = "preview-lab-js-uilib2",
+                )
+                lib2.assertOk()
+
+                // Stage 2: app は両 KLIB を `-libraries` で参照しつつ collectAllModulePreviews を使う。
+                // marker class 命名が module hash で unique なので、両 lib の `previewLabExport(<Marker>)`
+                // は IdSignature が衝突せず link 可能。
+                val app = base.compileJs(
+                    SourceFile.kotlin(
+                        "App.kt",
+                        """
+                    package app
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun AppPreview() {}
+                    """,
+                    ),
+                    base.collectAllModulePreviewsEntry("appPreviews"),
+                    extraLibraries = lib1.klibFiles() + lib2.klibFiles(),
+                    moduleName = "preview-lab-js-app",
+                )
+                app.assertOk()
+            }
+
+            test("manual collectModulePreviews delegate を持つ依存 KLIB を app が集約できる") {
+                val lib = base.compileJs(
+                    SourceFile.kotlin(
+                        "UiLib.kt",
+                        """
+                    package uilib
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun UiLibPreview() {}
+
+                    val uiLibPreviews by me.tbsten.compose.preview.lab.collectModulePreviews()
+                    """,
+                    ),
+                    moduleName = "preview-lab-js-uilib-manual",
+                )
+                lib.assertOk()
+
+                val app = base.compileJs(
+                    SourceFile.kotlin(
+                        "App.kt",
+                        """
+                    package app
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun AppPreview() {}
+                    """,
+                    ),
+                    base.collectAllModulePreviewsEntry("appPreviews"),
+                    extraLibraries = lib.klibFiles(),
+                    moduleName = "preview-lab-js-app-manual",
+                )
+                app.assertOk()
+            }
+        },
+    )

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/CrossModuleAggregationKlibTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/CrossModuleAggregationKlibTest.kt
@@ -20,30 +20,65 @@ class CrossModuleAggregationKlibTest :
         {
             val base = CompilerPluginJsTestBase()
 
-            test("@Preview のみの単一モジュールが JS_IR backend で KLIB を生成できる") {
-                val result = base.compileJs(
-                    SourceFile.kotlin(
-                        "Lib.kt",
-                        """
-                    package uilib
+            // Mirror the version gate used by `PreviewLabFirExtensionRegistrar` /
+            // `CompatContext.supportsKlibCrossModuleHint()`. Below 2.3.21 the FIR-side
+            // hint generator is not registered at all, so these tests cannot exercise
+            // the marker-class scheme they depend on. Skipping rather than failing keeps
+            // the older-Kotlin smoke matrix (`scripts/compiler-plugin-test.sh`) green.
+            val testKotlinVersion = System.getProperty("test.kotlin.version") ?: "2.3.21"
+            val supportsKlibHint = testKotlinVersion.compareTo("2.3.21") >= 0 ||
+                testKotlinVersion.startsWith("2.4")
 
-                    @org.jetbrains.compose.ui.tooling.preview.Preview
-                    fun UiLibPreview1() {}
+            test("E-1: 単一依存モジュールの @Preview が app の collectAllModulePreviews() から aggregation 可能")
+                .config(enabled = supportsKlibHint) {
+                    // Stage 1: 依存 KLIB を ビルド (この KLIB は @Preview のみを持つ)
+                    val lib = base.compileJs(
+                        SourceFile.kotlin(
+                            "Lib.kt",
+                            """
+                        package uilib
 
-                    @org.jetbrains.compose.ui.tooling.preview.Preview
-                    fun UiLibPreview2() {}
-                    """,
-                    ),
-                )
-                result.assertOk()
-            }
+                        @org.jetbrains.compose.ui.tooling.preview.Preview
+                        fun UiLibPreview1() {}
 
-            test("依存 KLIB 2 つを含む app の JS_IR compile が IdSignature 衝突なく成功する") {
-                // Stage 1a: uiLib1 の KLIB
-                val lib1 = base.compileJs(
-                    SourceFile.kotlin(
-                        "UiLib1.kt",
-                        """
+                        @org.jetbrains.compose.ui.tooling.preview.Preview
+                        fun UiLibPreview2() {}
+                        """,
+                        ),
+                        moduleName = "preview-lab-js-e1-lib",
+                    )
+                    lib.assertOk()
+
+                    // Stage 2: app は依存 KLIB を `-libraries` で参照しつつ
+                    // `collectAllModulePreviews()` を呼ぶ。FIR-emitted hint と marker class が
+                    // KLIB に含まれていなければここで unresolved reference になる。
+                    val app = base.compileJs(
+                        SourceFile.kotlin(
+                            "App.kt",
+                            """
+                        package app
+
+                        @org.jetbrains.compose.ui.tooling.preview.Preview
+                        fun AppPreview() {}
+                        """,
+                        ),
+                        base.collectAllModulePreviewsEntry("appPreviews"),
+                        extraLibraries = lib.klibFiles(),
+                        moduleName = "preview-lab-js-e1-app",
+                    )
+                    app.assertOk()
+                    // Note: kctfork の JS_IR backend は KLIB output のみ作るので、preview ID 単位の
+                    // runtime 値検証は不可。「依存 preview の id が含まれる」確認は PR2 の
+                    // integrationTest (実 Gradle build + node 実行) スコープ。
+                }
+
+            test("依存 KLIB 2 つを含む app の JS_IR compile が IdSignature 衝突なく成功する")
+                .config(enabled = supportsKlibHint) {
+                    // Stage 1a: uiLib1 の KLIB
+                    val lib1 = base.compileJs(
+                        SourceFile.kotlin(
+                            "UiLib1.kt",
+                            """
                     package uilib1
 
                     @org.jetbrains.compose.ui.tooling.preview.Preview
@@ -52,51 +87,52 @@ class CrossModuleAggregationKlibTest :
                     @org.jetbrains.compose.ui.tooling.preview.Preview
                     fun UiLib1Preview2() {}
                     """,
-                    ),
-                    moduleName = "preview-lab-js-uilib1",
-                )
-                lib1.assertOk()
+                        ),
+                        moduleName = "preview-lab-js-uilib1",
+                    )
+                    lib1.assertOk()
 
-                // Stage 1b: uiLib2 の KLIB
-                val lib2 = base.compileJs(
-                    SourceFile.kotlin(
-                        "UiLib2.kt",
-                        """
+                    // Stage 1b: uiLib2 の KLIB
+                    val lib2 = base.compileJs(
+                        SourceFile.kotlin(
+                            "UiLib2.kt",
+                            """
                     package uilib2
 
                     @org.jetbrains.compose.ui.tooling.preview.Preview
                     fun UiLib2Preview() {}
                     """,
-                    ),
-                    moduleName = "preview-lab-js-uilib2",
-                )
-                lib2.assertOk()
+                        ),
+                        moduleName = "preview-lab-js-uilib2",
+                    )
+                    lib2.assertOk()
 
-                // Stage 2: app は両 KLIB を `-libraries` で参照しつつ collectAllModulePreviews を使う。
-                // marker class 命名が module hash で unique なので、両 lib の `previewLabExport(<Marker>)`
-                // は IdSignature が衝突せず link 可能。
-                val app = base.compileJs(
-                    SourceFile.kotlin(
-                        "App.kt",
-                        """
+                    // Stage 2: app は両 KLIB を `-libraries` で参照しつつ collectAllModulePreviews を使う。
+                    // marker class 命名が module hash で unique なので、両 lib の `previewLabExport(<Marker>)`
+                    // は IdSignature が衝突せず link 可能。
+                    val app = base.compileJs(
+                        SourceFile.kotlin(
+                            "App.kt",
+                            """
                     package app
 
                     @org.jetbrains.compose.ui.tooling.preview.Preview
                     fun AppPreview() {}
                     """,
-                    ),
-                    base.collectAllModulePreviewsEntry("appPreviews"),
-                    extraLibraries = lib1.klibFiles() + lib2.klibFiles(),
-                    moduleName = "preview-lab-js-app",
-                )
-                app.assertOk()
-            }
+                        ),
+                        base.collectAllModulePreviewsEntry("appPreviews"),
+                        extraLibraries = lib1.klibFiles() + lib2.klibFiles(),
+                        moduleName = "preview-lab-js-app",
+                    )
+                    app.assertOk()
+                }
 
-            test("manual collectModulePreviews delegate を持つ依存 KLIB を app が集約できる") {
-                val lib = base.compileJs(
-                    SourceFile.kotlin(
-                        "UiLib.kt",
-                        """
+            test("manual collectModulePreviews delegate を持つ依存 KLIB を app が集約できる")
+                .config(enabled = supportsKlibHint) {
+                    val lib = base.compileJs(
+                        SourceFile.kotlin(
+                            "UiLib.kt",
+                            """
                     package uilib
 
                     @org.jetbrains.compose.ui.tooling.preview.Preview
@@ -104,36 +140,37 @@ class CrossModuleAggregationKlibTest :
 
                     val uiLibPreviews by me.tbsten.compose.preview.lab.collectModulePreviews()
                     """,
-                    ),
-                    moduleName = "preview-lab-js-uilib-manual",
-                )
-                lib.assertOk()
+                        ),
+                        moduleName = "preview-lab-js-uilib-manual",
+                    )
+                    lib.assertOk()
 
-                val app = base.compileJs(
-                    SourceFile.kotlin(
-                        "App.kt",
-                        """
+                    val app = base.compileJs(
+                        SourceFile.kotlin(
+                            "App.kt",
+                            """
                     package app
 
                     @org.jetbrains.compose.ui.tooling.preview.Preview
                     fun AppPreview() {}
                     """,
-                    ),
-                    base.collectAllModulePreviewsEntry("appPreviews"),
-                    extraLibraries = lib.klibFiles(),
-                    moduleName = "preview-lab-js-app-manual",
-                )
-                app.assertOk()
-            }
+                        ),
+                        base.collectAllModulePreviewsEntry("appPreviews"),
+                        extraLibraries = lib.klibFiles(),
+                        moduleName = "preview-lab-js-app-manual",
+                    )
+                    app.assertOk()
+                }
 
-            test("E-2: 同名 collectModulePreviews property を持つ依存 2 つでも IdSignature 衝突しない") {
-                // 両モジュールが同じプロパティ名 `sharedPreviews` を持つ。旧 IR-based hint scheme では
-                // `previewLabExport(PreviewExport)` の IdSignature が両モジュールで一致して link 失敗するが、
-                // 新 FIR-based path では module-name-hash で marker class を unique 化しているので両方 link 成功する。
-                val lib1 = base.compileJs(
-                    SourceFile.kotlin(
-                        "Lib1.kt",
-                        """
+            test("E-2: 同名 collectModulePreviews property を持つ依存 2 つでも IdSignature 衝突しない")
+                .config(enabled = supportsKlibHint) {
+                    // 両モジュールが同じプロパティ名 `sharedPreviews` を持つ。旧 IR-based hint scheme では
+                    // `previewLabExport(PreviewExport)` の IdSignature が両モジュールで一致して link 失敗するが、
+                    // 新 FIR-based path では module-name-hash で marker class を unique 化しているので両方 link 成功する。
+                    val lib1 = base.compileJs(
+                        SourceFile.kotlin(
+                            "Lib1.kt",
+                            """
                     package lib1
 
                     @org.jetbrains.compose.ui.tooling.preview.Preview
@@ -141,15 +178,15 @@ class CrossModuleAggregationKlibTest :
 
                     val sharedPreviews by me.tbsten.compose.preview.lab.collectModulePreviews()
                     """,
-                    ),
-                    moduleName = "preview-lab-js-collide-lib1",
-                )
-                lib1.assertOk()
+                        ),
+                        moduleName = "preview-lab-js-collide-lib1",
+                    )
+                    lib1.assertOk()
 
-                val lib2 = base.compileJs(
-                    SourceFile.kotlin(
-                        "Lib2.kt",
-                        """
+                    val lib2 = base.compileJs(
+                        SourceFile.kotlin(
+                            "Lib2.kt",
+                            """
                     package lib2
 
                     @org.jetbrains.compose.ui.tooling.preview.Preview
@@ -157,62 +194,63 @@ class CrossModuleAggregationKlibTest :
 
                     val sharedPreviews by me.tbsten.compose.preview.lab.collectModulePreviews()
                     """,
-                    ),
-                    moduleName = "preview-lab-js-collide-lib2",
-                )
-                lib2.assertOk()
+                        ),
+                        moduleName = "preview-lab-js-collide-lib2",
+                    )
+                    lib2.assertOk()
 
-                val app = base.compileJs(
-                    SourceFile.kotlin(
-                        "App.kt",
-                        """
+                    val app = base.compileJs(
+                        SourceFile.kotlin(
+                            "App.kt",
+                            """
                     package app
 
                     @org.jetbrains.compose.ui.tooling.preview.Preview
                     fun AppPreview() {}
                     """,
-                    ),
-                    base.collectAllModulePreviewsEntry("appPreviews"),
-                    extraLibraries = lib1.klibFiles() + lib2.klibFiles(),
-                    moduleName = "preview-lab-js-collide-app",
-                )
-                app.assertOk()
-            }
+                        ),
+                        base.collectAllModulePreviewsEntry("appPreviews"),
+                        extraLibraries = lib1.klibFiles() + lib2.klibFiles(),
+                        moduleName = "preview-lab-js-collide-app",
+                    )
+                    app.assertOk()
+                }
 
-            test("E-4: @Preview を持たない依存モジュールが含まれていても link が壊れない") {
-                // empty な依存 KLIB (preview / property どちらも無し)。FIR generator は依然として
-                // marker + hint を出すので、auto-provider が空リストを返す形で生成される必要がある。
-                // (P1 fix を入れる前は previews.isEmpty() で provider 生成を skip していたため、
-                // 下流の `referenceFunctions` が空になり aggregation 自体は動くが、provider 不在の
-                // hint が残る奇妙な状態になっていた。)
-                val emptyLib = base.compileJs(
-                    SourceFile.kotlin(
-                        "EmptyLib.kt",
-                        """
+            test("E-4: @Preview を持たない依存モジュールが含まれていても link が壊れない")
+                .config(enabled = supportsKlibHint) {
+                    // empty な依存 KLIB (preview / property どちらも無し)。FIR generator は依然として
+                    // marker + hint を出すので、auto-provider が空リストを返す形で生成される必要がある。
+                    // (P1 fix を入れる前は previews.isEmpty() で provider 生成を skip していたため、
+                    // 下流の `referenceFunctions` が空になり aggregation 自体は動くが、provider 不在の
+                    // hint が残る奇妙な状態になっていた。)
+                    val emptyLib = base.compileJs(
+                        SourceFile.kotlin(
+                            "EmptyLib.kt",
+                            """
                     package emptylib
 
                     fun nonPreviewFunction(): Int = 42
                     """,
-                    ),
-                    moduleName = "preview-lab-js-empty-lib",
-                )
-                emptyLib.assertOk()
+                        ),
+                        moduleName = "preview-lab-js-empty-lib",
+                    )
+                    emptyLib.assertOk()
 
-                val app = base.compileJs(
-                    SourceFile.kotlin(
-                        "App.kt",
-                        """
+                    val app = base.compileJs(
+                        SourceFile.kotlin(
+                            "App.kt",
+                            """
                     package app
 
                     @org.jetbrains.compose.ui.tooling.preview.Preview
                     fun AppPreview() {}
                     """,
-                    ),
-                    base.collectAllModulePreviewsEntry("appPreviews"),
-                    extraLibraries = emptyLib.klibFiles(),
-                    moduleName = "preview-lab-js-empty-app",
-                )
-                app.assertOk()
-            }
+                        ),
+                        base.collectAllModulePreviewsEntry("appPreviews"),
+                        extraLibraries = emptyLib.klibFiles(),
+                        moduleName = "preview-lab-js-empty-app",
+                    )
+                    app.assertOk()
+                }
         },
     )


### PR DESCRIPTION
## Summary

bug-017 Step 5: KLIB cross-module preview aggregation を JS_IR backend でユニットテスト化。

- 既存 `CrossModuleAggregationTest` (JVM) は class loader 経由の linking のみ検証。
- 本 PR は kctfork `KotlinJsCompilation` で 2 段 KLIB ビルドを走らせ、IdSignature 衝突回避ロジックと marker class ベースの cross-module discovery が JS_IR backend で実際に動くことを担保する。

## 追加ファイル

- `compiler-plugin/src/test/kotlin/.../CompilerPluginJsTestBase.kt` — JS_IR テストヘルパー
- `compiler-plugin/src/test/kotlin/.../feature/CrossModuleAggregationKlibTest.kt` — 3 ケースのテスト
  1. `@Preview` のみの単一モジュールが KLIB を生成できる
  2. 依存 KLIB 2 つを含む app の compile が IdSignature 衝突なく成功する
  3. manual `collectModulePreviews` delegate を持つ依存 KLIB を app が集約できる

## Build infra

- `kotlin-stdlib-js@klib` を resolvable configuration で取り込み (KMP variant resolution の JVM consumer 拒否を回避)
- `StdlibJsKlibArgumentProvider` で system property として test JVM に渡す (configuration-cache 互換)
- `KotlinJsCompilation.args.libraries` は `kotlincArguments = ["-libraries", ...]` で上書き

## Test plan

- [x] `./gradlew :compiler-plugin:test --continue` 全 PASS (45/45 含む新規 KLIB test 3/3)
- [x] `./gradlew :compiler-plugin:ktlintCheck` PASS
- [x] Configuration cache stored OK
- [ ] CI 全 PASS

## Base PR

依存: #165 (Step 3+4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)