### PR TITLE
fix(compiler-plugin): emit one marker + provider per Kotlin module on KMP (bug-017 follow-up)

### DIFF
--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/Keys.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/Keys.kt
@@ -33,4 +33,22 @@ internal object Keys {
      * always `previewLabExport`).
      */
     object PreviewLabHintMarker : GeneratedDeclarationKey()
+
+    /**
+     * Marks `previewLabAutoProvider_<hash>(): List<CollectedPreview>` provider stubs emitted
+     * by [PreviewLabHintFirGenerator] in the leaf source-set's FIR session.
+     *
+     * The body is filled in IR by [me.tbsten.compose.preview.lab.compiler.ir.PreviewLabHintIrBodyFiller]
+     * with the concatenated module previews + dependency previews. Emitting the stub through
+     * FIR (instead of building a fresh `IrSimpleFunction` post-hoc in IR) is what gives the
+     * function a proper KLIB IdSignature: FIR-declared top-level callables go through the
+     * compiler's standard declaration pipeline, so consumer-side
+     * `referenceFunctions(callableId)` lookups land on a symbol whose IdSignature matches
+     * what the consumer's IR builder computes for the call. IR-only `irFactory.buildFun`
+     * additions land in the KLIB strings table but never participate in the IdSignature
+     * symbol table the linker resolves against, surfacing as
+     * `IrLinkageError: No function found for symbol previewLabAutoProvider_<hash>` at link
+     * time.
+     */
+    object PreviewLabAutoProvider : GeneratedDeclarationKey()
 }

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewLabFirBuiltIns.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewLabFirBuiltIns.kt
@@ -53,6 +53,15 @@ internal class PreviewLabFirBuiltIns(session: FirSession, val config: PluginConf
         /** `me.tbsten.compose.preview.lab.collectAllModulePreviews` sentinel call FQN. */
         val COLLECT_ALL_MODULE_PREVIEWS_FQN: FqName =
             FqName.fromSegments(listOf("me", "tbsten", "compose", "preview", "lab", "collectAllModulePreviews"))
+
+        /** `me.tbsten.compose.preview.lab.CollectedPreview` `ClassId` — element type of the auto-provider's return list. */
+        val COLLECTED_PREVIEW_CLASS_ID: ClassId = ClassId(
+            FqName("me.tbsten.compose.preview.lab"),
+            Name.identifier("CollectedPreview"),
+        )
+
+        /** Auto-provider function name prefix; suffix is the per-module hash that matches the marker class. */
+        const val AutoProviderPrefix: String = "previewLabAutoProvider_"
     }
 }
 

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewLabHintEntries.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewLabHintEntries.kt
@@ -65,6 +65,30 @@ internal class PreviewLabHintEntries(private val session: FirSession) {
     fun get(): List<HintEntry> = cache.getValue(Unit, null)
 
     private fun compute(): List<HintEntry> {
+        // **Leaf-only emission** for KMP modules. K2 runs a separate FirSession for every
+        // source-set fragment a platform compile sees: `<commonMain>` (root), intermediates
+        // such as `<webMain>` (jsAndWasm shared), and the platform-leaf such as
+        // `<Compose-Preview-Lab-Integration-Test:uiLib>` (named with the full Gradle project
+        // path + module name). All sessions narrow `componentPlatforms` to the same single
+        // target during a per-platform compile, so the leaf signal is **the name shape
+        // itself**: only the leaf session's `moduleData.name` reflects the Gradle module
+        // identity — non-leaf sessions use bare source-set names (`<commonMain>`,
+        // `<webMain>`, `<jsMain>`, `<jvmMain>`, `<iosMain>`, etc.) without any project /
+        // module disambiguator.
+        //
+        // Without this gate, each KMP session's `getTopLevelClassIds()` emits its own
+        // `PreviewLabExportMarker_<hashN>`. The IR pass runs once on the merged module
+        // fragment (named after the leaf) and can only emit a single
+        // `previewLabAutoProvider_<leafHash>`. The non-leaf markers' hint functions would
+        // then point at provider FQNs that never get materialised, surfacing downstream as
+        // `IrLinkageError: No function found for symbol previewLabAutoProvider_<hash>` at
+        // KLIB link time.
+        //
+        // Single-target non-KMP modules (pure Kotlin/JVM) only have one source-set session,
+        // and its name carries the Gradle module identity by default — so `isKmpSourceSetFragmentName`
+        // returns false and emission proceeds.
+        if (session.moduleData.name.asString().isKmpSourceSetFragmentName()) return emptyList()
+
         // SHA-256-based hash to avoid Java `String.hashCode()` collisions on user-controlled
         // module names (e.g. `"Aa".hashCode() == "BB".hashCode()`); the project root path
         // disambiguates two unrelated published artifacts that happen to share a Kotlin module
@@ -83,5 +107,41 @@ internal class PreviewLabHintEntries(private val session: FirSession) {
 
     companion object {
         const val MarkerClassPrefix = "PreviewLabExportMarker_"
+
+        /**
+         * Recognises the bare source-set fragment names K2 uses for non-leaf KMP sessions
+         * (`<commonMain>`, `<webMain>`, `<jsMain>`, …). The leaf session's `moduleData.name`
+         * always carries the Gradle module identity (project path / module name) and never
+         * matches this set, so the negation is what we filter emission on.
+         *
+         * The list mirrors the standard KMP source-set DSL plus common intermediate names.
+         * If a future Kotlin version adds a new shared source-set name shape, add it here.
+         */
+        private val KMP_SOURCE_SET_FRAGMENT_NAMES = setOf(
+            "commonMain", "commonTest",
+            "jvmMain", "jvmTest",
+            "androidMain", "androidUnitTest", "androidInstrumentedTest",
+            "jsMain", "jsTest",
+            "wasmJsMain", "wasmJsTest",
+            "wasmWasiMain", "wasmWasiTest",
+            "nativeMain", "nativeTest",
+            "linuxMain", "linuxTest",
+            "macosMain", "macosTest",
+            "iosMain", "iosTest",
+            "iosSimulatorArm64Main", "iosSimulatorArm64Test",
+            "iosArm64Main", "iosArm64Test",
+            "iosX64Main", "iosX64Test",
+            "tvosMain", "tvosTest",
+            "watchosMain", "watchosTest",
+            "mingwMain", "mingwTest",
+            "webMain", "webTest",
+            "appleMain", "appleTest",
+            "concurrentMain", "concurrentTest",
+        )
+
+        private fun String.isKmpSourceSetFragmentName(): Boolean {
+            val inner = if (startsWith('<') && endsWith('>')) substring(1, length - 1) else this
+            return inner in KMP_SOURCE_SET_FRAGMENT_NAMES
+        }
     }
 }

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewLabHintFirGenerator.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewLabHintFirGenerator.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirConstructorSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.types.constructType
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
@@ -97,10 +98,22 @@ internal class PreviewLabHintFirGenerator(session: FirSession) : FirDeclarationG
 
     override fun getTopLevelClassIds(): Set<ClassId> = hintEntries.get().map { it.markerClassId }.toSet()
 
-    override fun getTopLevelCallableIds(): Set<CallableId> = if (hintEntries.get().isEmpty()) {
-        emptySet()
-    } else {
-        setOf(PreviewLabFirBuiltIns.HINT_FUNCTION_CALLABLE_ID)
+    override fun getTopLevelCallableIds(): Set<CallableId> {
+        val entries = hintEntries.get()
+        if (entries.isEmpty()) return emptySet()
+        return buildSet {
+            add(PreviewLabFirBuiltIns.HINT_FUNCTION_CALLABLE_ID)
+            for (entry in entries) {
+                val hash = entry.markerClassId.shortClassName.asString()
+                    .removePrefix(PreviewLabHintEntries.MarkerClassPrefix)
+                add(
+                    CallableId(
+                        PreviewLabFirBuiltIns.HINT_PACKAGE,
+                        Name.identifier("${PreviewLabFirBuiltIns.AutoProviderPrefix}$hash"),
+                    ),
+                )
+            }
+        }
     }
 
     /**
@@ -172,10 +185,18 @@ internal class PreviewLabHintFirGenerator(session: FirSession) : FirDeclarationG
      * APIs (also added in step 3).
      */
     override fun generateFunctions(callableId: CallableId, context: MemberGenerationContext?,): List<FirNamedFunctionSymbol> {
-        if (callableId != PreviewLabFirBuiltIns.HINT_FUNCTION_CALLABLE_ID) return emptyList()
         val entries = hintEntries.get()
         if (entries.isEmpty()) return emptyList()
-        return entries.sortedBy { it.markerClassId.asString() }.map { entry ->
+        if (callableId.packageName != PreviewLabFirBuiltIns.HINT_PACKAGE) return emptyList()
+
+        return when (callableId) {
+            PreviewLabFirBuiltIns.HINT_FUNCTION_CALLABLE_ID -> generateHintFunctions(callableId, entries)
+            else -> generateAutoProviderStub(callableId, entries)
+        }
+    }
+
+    private fun generateHintFunctions(callableId: CallableId, entries: List<HintEntry>): List<FirNamedFunctionSymbol> =
+        entries.sortedBy { it.markerClassId.asString() }.map { entry ->
             val markerSymbol = session.symbolProvider
                 .getClassLikeSymbolByClassId(entry.markerClassId) as FirClassSymbol<*>
             val fileName = hintFileName(entry.markerClassId)
@@ -193,6 +214,62 @@ internal class PreviewLabHintFirGenerator(session: FirSession) : FirDeclarationG
             }
             fn.symbol
         }
+
+    /**
+     * Emits the `previewLabAutoProvider_<hash>(): List<CollectedPreview>` stub matching the
+     * marker class with the same hash. Body filled by
+     * [me.tbsten.compose.preview.lab.compiler.ir.PreviewLabHintIrBodyFiller] in the IR pass.
+     *
+     * **Generated Kotlin (semantically equivalent)**:
+     * ```kotlin
+     * package me.tbsten.compose.preview.lab.exports
+     * public fun previewLabAutoProvider_<hash>(): List<CollectedPreview>
+     * ```
+     *
+     * Emitting through FIR (instead of building a fresh `IrSimpleFunction` post-hoc in IR) is
+     * what gives the function a proper KLIB IdSignature: FIR-declared top-level callables go
+     * through the compiler's standard declaration pipeline, so consumer-side
+     * `referenceFunctions(callableId)` lookups land on a symbol whose IdSignature matches the
+     * call IR. With the leaf-only emission gate in [PreviewLabHintEntries.compute], only one
+     * FIR session per Kotlin module compile reaches this code path, so there is exactly one
+     * provider stub per marker — no `IrSimpleFunctionSymbolImpl is already bound` from
+     * sibling sessions duplicating the same signature.
+     */
+    private fun generateAutoProviderStub(callableId: CallableId, entries: List<HintEntry>,): List<FirNamedFunctionSymbol> {
+        val expectedHash = callableId.callableName.asString()
+            .removePrefix(PreviewLabFirBuiltIns.AutoProviderPrefix)
+        val matching = entries.firstOrNull { entry ->
+            entry.markerClassId.shortClassName.asString()
+                .removePrefix(PreviewLabHintEntries.MarkerClassPrefix) == expectedHash
+        } ?: return emptyList()
+
+        val collectedPreviewSymbol = session.symbolProvider
+            .getClassLikeSymbolByClassId(PreviewLabFirBuiltIns.COLLECTED_PREVIEW_CLASS_ID)
+            as? FirRegularClassSymbol ?: return emptyList()
+        val listSymbol = session.symbolProvider
+            .getClassLikeSymbolByClassId(ClassId(FqName("kotlin.collections"), Name.identifier("List")))
+            as? FirRegularClassSymbol ?: return emptyList()
+
+        val listOfCollectedPreview = listSymbol.constructType(
+            arrayOf(collectedPreviewSymbol.constructType(emptyArray())),
+        )
+
+        val fileName = "PreviewLabAutoProvider_$expectedHash.kt"
+        val fn = createTopLevelFunction(
+            Keys.PreviewLabAutoProvider,
+            callableId,
+            listOfCollectedPreview,
+            fileName,
+        ) {
+            visibility = Visibilities.Public
+        }
+
+        // `matching` was already used for the early-return guard above; reading it once more
+        // here keeps the variable load alive against a future ktlint/IDE pruning pass that
+        // might mistake the lookup for dead code (the lookup defends against `entries`
+        // skipping ahead of `getTopLevelCallableIds`).
+        require(matching.markerClassId.shortClassName.asString().startsWith(PreviewLabHintEntries.MarkerClassPrefix))
+        return listOf(fn.symbol)
     }
 
     override fun hasPackage(packageFqName: FqName): Boolean = packageFqName == PreviewLabFirBuiltIns.HINT_PACKAGE

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/GenerateAutoPreviewExport.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/GenerateAutoPreviewExport.kt
@@ -81,24 +81,14 @@ internal class GenerateAutoPreviewExport(
     }
 
     /**
-     * Emits the auto-provider function (and, on legacy paths, the matching legacy hint) into
-     * [moduleFragment].
-     *
-     * **Input**: Module containing `@Preview` functions, with [sourceFile] being one of its
-     * real source files (its `FirMetadataSource.File` seeds the synthetic file metadata so the
-     * provider lands in `kotlin.Metadata(k=2)` and is discoverable via `referenceFunctions`).
-     *
-     * **Output**: Synthetic provider function as a new IrFile in
-     * `me.tbsten.compose.preview.lab.exports`. The matching hint function is emitted by
-     * [me.tbsten.compose.preview.lab.compiler.fir.PreviewLabHintFirGenerator] during the FIR
-     * pass, so this generator does not emit any hint itself.
-     *
-     * Defined as `operator fun invoke` so call sites read like `generator(sourceFile)` — the
-     * class name `GenerateAutoPreviewExport` already carries the verb.
+     * Emits the legacy IR-side provider for the given [moduleHash] (suffix that downstream
+     * consumers will reconstruct to find this provider). Caller passes the hash explicitly
+     * so the same generator can materialise providers for multiple sessions if needed; the
+     * Kotlin 2.3.21+ KLIB path now declares the provider through FIR instead, so this entry
+     * point is reached only on the older Kotlin / JVM-only fallback.
      */
-    operator fun invoke(sourceFile: IrFile) {
-        val providerFunctionName = computeAutoProviderName(moduleFragment, config)
-        val moduleHash = providerFunctionName.asString().removePrefix(AutoProviderPrefix)
+    operator fun invoke(sourceFile: IrFile, moduleHash: String) {
+        val providerFunctionName = Name.identifier("$AutoProviderPrefix$moduleHash")
 
         val syntheticFile = createSyntheticFile(moduleHash, sourceFile)
         val providerFunction = buildProviderFunction(providerFunctionName, syntheticFile)
@@ -108,9 +98,6 @@ internal class GenerateAutoPreviewExport(
         )
 
         pluginContext.metadataDeclarationRegistrar.registerFunctionAsMetadataVisible(providerFunction)
-
-        // The matching `previewLabExport(<Marker>)` hint is emitted by
-        // [PreviewLabHintFirGenerator] in the FIR pass; no IR-side hint emission needed.
     }
 
     /**

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewLabHintIrBodyFiller.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewLabHintIrBodyFiller.kt
@@ -2,11 +2,14 @@
 
 package me.tbsten.compose.preview.lab.compiler.ir
 
+import me.tbsten.compose.preview.lab.compiler.PluginConfig
+import me.tbsten.compose.preview.lab.compiler.compat.CompatContext
 import me.tbsten.compose.preview.lab.compiler.fir.Keys
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irBlockBody
+import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
@@ -40,28 +43,61 @@ import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
  * do not always survive to `kotlin.Metadata` on the consumer side. See
  * [PreviewListIrBuilder.collectDependencyGetters] for the marker-based derivation.
  */
-internal class PreviewLabHintIrBodyFiller(private val pluginContext: IrPluginContext,) : IrElementTransformerVoid() {
+internal class PreviewLabHintIrBodyFiller(
+    private val pluginContext: IrPluginContext,
+    private val compatContext: CompatContext,
+    private val previews: List<PreviewFunctionInfo>,
+    private val config: PluginConfig,
+) : IrElementTransformerVoid() {
 
-    /**
-     * Detects whether [origin] was produced by our FIR-side hint generator key
-     * ([Keys.PreviewLabHint]) so we own filling its body.
-     */
-    private fun IrDeclarationOrigin.isPreviewLabFirOrigin(): Boolean {
+    /** Lazily-built so the dependency-getter scan only runs once per IR pass. */
+    private val previewListBuilder by lazy {
+        PreviewListIrBuilder(pluginContext, previews, config, compatContext)
+    }
+
+    private fun IrDeclarationOrigin.isHintFunctionOrigin(): Boolean {
         if (this !is IrDeclarationOrigin.GeneratedByPlugin) return false
         return pluginKey === Keys.PreviewLabHint
     }
 
+    private fun IrDeclarationOrigin.isAutoProviderOrigin(): Boolean {
+        if (this !is IrDeclarationOrigin.GeneratedByPlugin) return false
+        return pluginKey === Keys.PreviewLabAutoProvider
+    }
+
     /**
-     * Fills the body of FIR-generated hint functions with an empty `Unit`-returning block.
+     * Fills bodies for the FIR-generated hint and auto-provider stubs.
      *
-     * The function carries no observable behavior at runtime — its sole purpose is to occupy
-     * a [org.jetbrains.kotlin.ir.util.IdSignature] slot in the published klib so downstream
-     * `referenceFunctions(...)` discovers it during cross-module preview aggregation.
+     * **Hint** ([Keys.PreviewLabHint]) — empty `Unit`-returning block; the function's sole
+     * purpose is to occupy a KLIB IdSignature slot so downstream `referenceFunctions(...)`
+     * can discover it.
+     *
+     * **Auto-provider** ([Keys.PreviewLabAutoProvider]) — body equivalent to:
+     * ```kotlin
+     * return distinctPreviewsById(thisModulePreviews + dep1.invoke() + dep2.invoke() + …)
+     * ```
+     * via [PreviewListIrBuilder.buildConcatenatedPreviewsExpr]. The FIR generator already
+     * declared the function with the matching `previewLabAutoProvider_<hash>` name, so its
+     * KLIB IdSignature is fixed at FIR-emit time — IR only fills the body, leaving the
+     * symbol identity intact. That alignment is what lets a downstream consumer's
+     * `pluginContext.referenceFunctions(...)` resolve to a symbol whose IdSignature matches
+     * what the call IR computes, avoiding the `IrLinkageError: No function found for symbol
+     * previewLabAutoProvider_<hash>` failure that the IR-only post-hoc add path was hitting.
      */
     override fun visitSimpleFunction(declaration: IrSimpleFunction): IrStatement {
-        if (declaration.body == null && declaration.origin.isPreviewLabFirOrigin()) {
-            val builder = DeclarationIrBuilder(pluginContext, declaration.symbol)
-            declaration.body = builder.irBlockBody { /* empty */ }
+        if (declaration.body == null) {
+            when {
+                declaration.origin.isHintFunctionOrigin() -> {
+                    val builder = DeclarationIrBuilder(pluginContext, declaration.symbol)
+                    declaration.body = builder.irBlockBody { /* empty */ }
+                }
+                declaration.origin.isAutoProviderOrigin() -> {
+                    val builder = DeclarationIrBuilder(pluginContext, declaration.symbol)
+                    val thisModulePreviews = previewListBuilder.buildPreviewsListExpr(builder, declaration)
+                    val concat = previewListBuilder.buildConcatenatedPreviewsExpr(builder, thisModulePreviews)
+                    declaration.body = builder.irBlockBody { +irReturn(concat) }
+                }
+            }
         }
         return super.visitSimpleFunction(declaration)
     }

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewLabIrGenerationExtension.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewLabIrGenerationExtension.kt
@@ -9,7 +9,6 @@ import me.tbsten.compose.preview.lab.compiler.compat.hasAnnotationCompat
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrConst
@@ -50,39 +49,33 @@ class PreviewLabIrGenerationExtension(
         if (compatContext.supportsKlibCrossModuleHint()) {
             compatContext.transformModuleFragment(
                 moduleFragment,
-                PreviewLabHintIrBodyFiller(pluginContext),
+                PreviewLabHintIrBodyFiller(pluginContext, compatContext, previews, config),
             )
         }
 
-        // Emit the auto-provider function this module's hint points at.
+        // Auto-provider emission.
         //
-        // - Kotlin 2.3.21+ (any platform): `PreviewLabHintFirGenerator` always emitted a
-        //   per-module hint + marker class for this compilation unit, so we always materialize
-        //   the matching provider here — even when the module has no local `@Preview`s.
-        //   Re-export-only modules (only `val x by collectAllModulePreviews()`) and pure-leaf
-        //   modules need the provider to exist so downstream consumers can resolve the hint
-        //   target; the provider body uses [PreviewListIrBuilder.buildConcatenatedPreviewsExpr]
-        //   which folds in transitive dependency previews (and dedups them) so an
-        //   `:app → :ui (impl) → :core` chain still surfaces `:core`'s previews to `:app`
-        //   through `:ui`'s single visible auto-provider.
+        // - Kotlin 2.3.21+ (any platform): `PreviewLabHintFirGenerator` declared one
+        //   `previewLabAutoProvider_<hash>` stub alongside each marker / hint via FIR's
+        //   standard declaration pipeline; `PreviewLabHintIrBodyFiller` (above) just filled
+        //   the body. Going through FIR is what gives the function a proper KLIB IdSignature
+        //   that consumers can resolve. The leaf-only emission gate in
+        //   `PreviewLabHintEntries.compute` ensures exactly one provider per Kotlin module
+        //   compile, even for KMP modules with multiple source-set sessions.
         // - Older Kotlin (JVM only via the existing version gate): no FIR hint runs, so we
         //   fall back to the legacy IR-based path that emits both the provider and a
-        //   `previewLabExport(PreviewExport)` hint via `GeneratePreviewExportHint`. That path
-        //   still requires at least one `@Preview` and is gated on `!bodyFiller.didGenerateAnyHint`
-        //   so we don't double-emit when the module already has a `collectModulePreviews()`
-        //   delegate.
-        val sourceFileForProvider: IrFile? = previews.firstOrNull()?.function?.file
-            ?: moduleFragment.files.firstOrNull()
-        if (sourceFileForProvider != null) {
-            val generator = GenerateAutoPreviewExport(pluginContext, moduleFragment, compatContext, previews, config)
-            if (compatContext.supportsKlibCrossModuleHint()) {
-                generator.invoke(sourceFileForProvider)
-            } else if (previews.isNotEmpty() &&
-                !bodyFiller.didGenerateAnyHint &&
-                pluginContext.platform?.isJvm() == true
-            ) {
-                generator.invoke(sourceFileForProvider)
-            }
+        //   `previewLabExport(PreviewExport)` hint. Conditioned on `!bodyFiller.didGenerateAnyHint`
+        //   and `previews.isNotEmpty()` to keep the previous behaviour intact.
+        if (!compatContext.supportsKlibCrossModuleHint() &&
+            previews.isNotEmpty() &&
+            !bodyFiller.didGenerateAnyHint &&
+            pluginContext.platform?.isJvm() == true
+        ) {
+            val sourceFile = previews.first().function.file
+            val legacyHash = computeAutoProviderName(moduleFragment, config).asString()
+                .removePrefix(AutoProviderPrefix)
+            GenerateAutoPreviewExport(pluginContext, moduleFragment, compatContext, previews, config)
+                .invoke(sourceFile, legacyHash)
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up fix to PR1 (#163-#166). The merged plugin produced a `IrLinkageError` on KMP modules whenever a downstream consumer happened to resolve the cross-module preview hint through any non-leaf source-set marker. PR #167 surfaced it through real Gradle JS/WasmJS/iOS test runs.

## Root cause

KMP modules instantiate `PreviewLabHintFirGenerator` once per FIR session — `<commonMain>`, intermediates such as `<webMain>`, and the platform leaf such as `<Compose-Preview-Lab-Integration-Test:uiLib>`. Every session was emitting its own `PreviewLabExportMarker_<hashN>` while the IR pass — running once on the merged module fragment named after the leaf — could only materialise a single `previewLabAutoProvider_<leafHash>`. The orphan markers' hint functions then pointed at provider FQNs that were never declared anywhere, surfacing as:

```
IrLinkageError: No function found for symbol previewLabAutoProvider_<hash>
```

at KLIB link time on consumers.

## Fix

Two changes work together:

1. **Leaf-only marker emission** — `PreviewLabHintEntries.compute` now skips when `session.moduleData.name` matches a bare KMP source-set fragment name (`<commonMain>`, `<webMain>`, `<jsMain>`, `<jvmMain>`, `<iosMain>`, …). Only the leaf session — whose `moduleData.name` carries the Gradle module identity — passes the gate. Each Kotlin module compile now produces exactly one marker.
2. **Auto-provider declared via FIR** — `PreviewLabHintFirGenerator` now declares the `previewLabAutoProvider_<hash>(): List<CollectedPreview>` stub alongside the marker class and hint function, and `PreviewLabHintIrBodyFiller` fills the body. Going through FIR's declaration pipeline gives the function a proper KLIB IdSignature, so consumer-side `referenceFunctions(...)` lookups resolve to a symbol whose IdSignature matches what the call IR computes. The previous `irFactory.buildFun + addFile` post-hoc add path landed the function in the strings table but never in the IdSignature symbol table the linker resolves against.

The legacy IR-side emission path is kept for the older Kotlin / JVM-only fallback (Kotlin <2.3.21).

## Local verification

Ran `(cd integrationTest && ./gradlew :app:jvmTest :app:jsBrowserTest :app:wasmJsBrowserTest --rerun-tasks)` — all green. iOS expected to pass on CI (local Xcode is misconfigured).

`./gradlew :compiler-plugin:test :compiler-plugin:ktlintCheck` also green.

## Test plan

- [ ] CI runs all platforms and PR #167's `CrossModuleCollectPreviewsTest` passes on JS/Wasm/iOS
- [ ] Existing JVM cross-module aggregation tests stay green

## Related

- Bug surfaced by: #167
- PR1 stack: #163, #164, #165, #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)