### PR TITLE
feat(core): add @PreviewHint annotation and PreviewContent typealias for cross-module hint redesign

### DIFF
--- a/core/api/android/core.api
+++ b/core/api/android/core.api
@@ -80,6 +80,16 @@ public final class me/tbsten/compose/preview/lab/PreviewExport {
 	public final fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/util/List;
 }
 
+public abstract interface annotation class me/tbsten/compose/preview/lab/PreviewHint : java/lang/annotation/Annotation {
+	public abstract fun code ()Ljava/lang/String;
+	public abstract fun displayName ()Ljava/lang/String;
+	public abstract fun endLineNumber ()I
+	public abstract fun filePath ()Ljava/lang/String;
+	public abstract fun id ()Ljava/lang/String;
+	public abstract fun kdoc ()Ljava/lang/String;
+	public abstract fun startLineNumber ()I
+}
+
 public final class me/tbsten/compose/preview/lab/PreviewLabEvent {
 	public static final field $stable I
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/time/Instant;)V

--- a/core/api/core.klib.api
+++ b/core/api/core.klib.api
@@ -6,6 +6,25 @@
 // - Show declarations: true
 
 // Library unique name: <me.tbsten.compose.preview.lab:core>
+open annotation class me.tbsten.compose.preview.lab/PreviewHint : kotlin/Annotation { // me.tbsten.compose.preview.lab/PreviewHint|null[0]
+    constructor <init>(kotlin/String, kotlin/String, kotlin/String, kotlin/Int, kotlin/Int, kotlin/String, kotlin/String) // me.tbsten.compose.preview.lab/PreviewHint.<init>|<init>(kotlin.String;kotlin.String;kotlin.String;kotlin.Int;kotlin.Int;kotlin.String;kotlin.String){}[0]
+
+    final val code // me.tbsten.compose.preview.lab/PreviewHint.code|{}code[0]
+        final fun <get-code>(): kotlin/String // me.tbsten.compose.preview.lab/PreviewHint.code.<get-code>|<get-code>(){}[0]
+    final val displayName // me.tbsten.compose.preview.lab/PreviewHint.displayName|{}displayName[0]
+        final fun <get-displayName>(): kotlin/String // me.tbsten.compose.preview.lab/PreviewHint.displayName.<get-displayName>|<get-displayName>(){}[0]
+    final val endLineNumber // me.tbsten.compose.preview.lab/PreviewHint.endLineNumber|{}endLineNumber[0]
+        final fun <get-endLineNumber>(): kotlin/Int // me.tbsten.compose.preview.lab/PreviewHint.endLineNumber.<get-endLineNumber>|<get-endLineNumber>(){}[0]
+    final val filePath // me.tbsten.compose.preview.lab/PreviewHint.filePath|{}filePath[0]
+        final fun <get-filePath>(): kotlin/String // me.tbsten.compose.preview.lab/PreviewHint.filePath.<get-filePath>|<get-filePath>(){}[0]
+    final val id // me.tbsten.compose.preview.lab/PreviewHint.id|{}id[0]
+        final fun <get-id>(): kotlin/String // me.tbsten.compose.preview.lab/PreviewHint.id.<get-id>|<get-id>(){}[0]
+    final val kdoc // me.tbsten.compose.preview.lab/PreviewHint.kdoc|{}kdoc[0]
+        final fun <get-kdoc>(): kotlin/String // me.tbsten.compose.preview.lab/PreviewHint.kdoc.<get-kdoc>|<get-kdoc>(){}[0]
+    final val startLineNumber // me.tbsten.compose.preview.lab/PreviewHint.startLineNumber|{}startLineNumber[0]
+        final fun <get-startLineNumber>(): kotlin/Int // me.tbsten.compose.preview.lab/PreviewHint.startLineNumber.<get-startLineNumber>|<get-startLineNumber>(){}[0]
+}
+
 abstract interface me.tbsten.compose.preview.lab/PreviewLabPreview { // me.tbsten.compose.preview.lab/PreviewLabPreview|null[0]
     abstract val code // me.tbsten.compose.preview.lab/PreviewLabPreview.code|{}code[0]
         abstract fun <get-code>(): kotlin/String? // me.tbsten.compose.preview.lab/PreviewLabPreview.code.<get-code>|<get-code>(){}[0]

--- a/core/api/jvm/core.api
+++ b/core/api/jvm/core.api
@@ -44,6 +44,16 @@ public final class me/tbsten/compose/preview/lab/PreviewExport {
 	public final fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/util/List;
 }
 
+public abstract interface annotation class me/tbsten/compose/preview/lab/PreviewHint : java/lang/annotation/Annotation {
+	public abstract fun code ()Ljava/lang/String;
+	public abstract fun displayName ()Ljava/lang/String;
+	public abstract fun endLineNumber ()I
+	public abstract fun filePath ()Ljava/lang/String;
+	public abstract fun id ()Ljava/lang/String;
+	public abstract fun kdoc ()Ljava/lang/String;
+	public abstract fun startLineNumber ()I
+}
+
 public final class me/tbsten/compose/preview/lab/PreviewLabEvent {
 	public static final field $stable I
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/time/Instant;)V

--- a/core/src/commonMain/kotlin/me/tbsten/compose/preview/lab/PreviewHint.kt
+++ b/core/src/commonMain/kotlin/me/tbsten/compose/preview/lab/PreviewHint.kt
@@ -1,0 +1,54 @@
+package me.tbsten.compose.preview.lab
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Compose Preview Lab compiler plugin が emit する per-declaration hint 関数に attach される
+ * metadata 運搬用 annotation。
+ *
+ * V2 hint 機構（Metro 風 per-declaration hint）では、 `@Preview` ごとに 1 つの hint 関数が
+ * `me.tbsten.compose.preview.lab.exports` パッケージに `previewHint_<sha256(sourceFqn)>` という
+ * 名前で生成され、 この annotation を介して `CollectedPreview` の全 metadata を carry する。
+ *
+ * 下流の `collectAllModulePreviews()` 呼び出しは、 KLIB / kotlin.Metadata から
+ * `@PreviewHint` 付き関数を発見し、 ここに記録された各 field を `CollectedPreview` に復元する。
+ *
+ * ## Nullable の sentinel 表現
+ *
+ * Kotlin の annotation parameter は nullable を取れないため、 `CollectedPreview` の
+ * nullable フィールド（`String?`, `Int?`） は **sentinel 値** で表現する：
+ *
+ * - `String?` の null → `""` (空文字列)
+ * - `Int?` の null → `-1` (line 番号は 1-based なので衝突しない)
+ *
+ * producer (compiler plugin) は `PreviewFunctionInfo` の null を sentinel に変換、
+ * consumer (`collectAllModulePreviews()`) は sentinel を null に戻して `CollectedPreview` を構築する。
+ *
+ * ## 利用者向け注意
+ *
+ * このアノテーションは **compiler plugin が emit するもの** であり、 user は直接書かない。
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+public annotation class PreviewHint(
+    val id: String,
+    val displayName: String,
+    val filePath: String,
+    val startLineNumber: Int,
+    val endLineNumber: Int,
+    val code: String,
+    val kdoc: String,
+)
+
+/**
+ * V2 hint 関数の戻り値型。 `@Composable () -> Unit` の typealias。
+ *
+ * compiler plugin が生成する hint 関数 (`previewHint_<hash>()`) はこの型を return する。
+ * typealias 定義側に `@Composable` annotation を乗せることで、 利用側（FIR generator や
+ * IR body filler、 consumer 側 discovery） は typealias を ClassId 参照するだけで `@Composable`
+ * 処理が行われる。
+ *
+ * このアノテーションは **compiler plugin が emit する hint 関数の戻り値型**として使用される。
+ * user は直接利用しない。
+ */
+public typealias PreviewContent = @Composable () -> Unit


### PR DESCRIPTION
## Summary

- redesign-hint-mechanism の T01: V2 hint 機構の runtime 側 API を追加
- `@PreviewHint` annotation: `CollectedPreview` の全 metadata (id, displayName, filePath, startLineNumber, endLineNumber, code, kdoc) を carry。 nullable は sentinel (`""` / `-1`) で表現
- `PreviewContent` typealias = `@Composable () -> Unit`: hint 関数の戻り値型として後続 T02 で利用

このチケット単体では plugin の挙動は変わらず、 後続チケット (T02 V2 hint 機構実装) の基盤を提供。 旧 `@PreviewExportHint` は触っておらず（T06 で削除予定）、 既存 API の削除 / シグネチャ変更なし。

Refs: `.local/ticket/redesign-hint-mechanism/01-runtime-api.md`

## Test plan

- [x] `./gradlew :core:compileKotlinJvm` green
- [x] `./gradlew :core:apiCheck` pass
- [x] `./gradlew :core:jvmTest` green
- [x] `./gradlew ktlintCheck` pass
- [x] apiDump diff: `PreviewHint` annotation のみ追加、 既存 API の削除なし
- [x] `PreviewContent` typealias は ABI に出ない（typealias の通常挙動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)