### PR TITLE
feat(compiler-plugin): add per-declaration hint mechanism (Metro-style)

### DIFF
--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/Keys.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/Keys.kt
@@ -51,4 +51,20 @@ internal object Keys {
      * time.
      */
     object PreviewLabAutoProvider : GeneratedDeclarationKey()
+
+    /**
+     * Per-`@Preview` hint 関数を識別する key (Metro 風 per-declaration hint 方式)。
+     *
+     * 各 `@Preview` 関数に対し
+     * `me.tbsten.compose.preview.lab.hints/previewHint_<sha256(sourceFqn)>(): CollectedPreview`
+     * という hint stub を FIR で declare し、 IR で body を埋める。 旧モジュール集約 hint
+     * [PreviewLabHint] (`previewLabExport(value: Marker)`) と区別するためだけの key。
+     *
+     * 使用箇所:
+     * - [PreviewHintFirGeneratorV2] (FIR side): hint stub に origin として attach
+     * - [me.tbsten.compose.preview.lab.compiler.ir.PreviewHintIrBodyFillerV2] (IR side):
+     *   この key で hint 関数を識別し、 body に `CollectedPreview(...)` constructor 呼び出しを
+     *   `irReturn` する形で埋める
+     */
+    object PreviewLabHintV2 : GeneratedDeclarationKey()
 }

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewHintFirGeneratorV2.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewHintFirGeneratorV2.kt
@@ -1,0 +1,166 @@
+@file:OptIn(
+    org.jetbrains.kotlin.fir.extensions.ExperimentalTopLevelDeclarationsGenerationApi::class,
+)
+
+package me.tbsten.compose.preview.lab.compiler.fir
+
+import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.extensions.FirDeclarationGenerationExtension
+import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
+import org.jetbrains.kotlin.fir.extensions.MemberGenerationContext
+import org.jetbrains.kotlin.fir.extensions.predicate.LookupPredicate
+import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
+import org.jetbrains.kotlin.fir.plugin.createTopLevelFunction
+import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
+import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.types.constructType
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+/**
+ * Per-declaration hint generator (Metro 風)。 `@Preview` annotation 付き top-level 関数 1 つに
+ * つき 1 つの hint stub `previewHint_<sha256(sourceFqn)>(): CollectedPreview` を
+ * `me.tbsten.compose.preview.lab.hints` package に emit する。
+ *
+ * **Generated Kotlin (semantically equivalent), per `@Preview`**:
+ *
+ * ```kotlin
+ * // file: previewHint_<hash>.kt
+ * package me.tbsten.compose.preview.lab.hints
+ *
+ * public fun previewHint_<hash>(): CollectedPreview =
+ *     error("Stub! Filled by IR.")
+ * ```
+ *
+ * 戻り値型 / 関数名のみ FIR で declare し、 metadata を含む `CollectedPreview(...)` constructor
+ * 呼び出しは IR 側 ([me.tbsten.compose.preview.lab.compiler.ir.PreviewHintIrBodyFillerV2]) で
+ * 注入する。 IR pass 後の hint は次のような形になる:
+ *
+ * ```kotlin
+ * public fun previewHint_<hash>(): CollectedPreview = CollectedPreview(
+ *     id = "uiLib.button.MyButton",
+ *     displayName = "uiLib.button.MyButton",
+ *     filePath = "uiLib/src/.../MyButton.kt",
+ *     startLineNumber = 5,
+ *     endLineNumber = 9,
+ *     code = "{ ... }",
+ *     kdoc = null,
+ *     content = @Composable { uiLib.button.MyButton() },
+ * )
+ * ```
+ *
+ * 旧モジュール集約 hint (`previewLabAutoProvider_<hash>(): List<CollectedPreview>`) を
+ * per-declaration に分解した形になる。 metadata を annotation で carry する代わりに、
+ * `CollectedPreview` の constructor 引数として直接運ぶ設計に倒した (FIR 側で
+ * `FirAnnotationCall` を resolved phase で組む煩雑さを回避するため)。
+ *
+ * # 設計ポイント
+ *
+ * - **関数名**: `previewHint_<sha256(sourceFqn)>` 。 sourceFqn のみを入力にすることで
+ *   incremental compile / 再現可能ビルドを保つ。 同 FQN cross-artifact collision は受容済み
+ *   edge case (`.local/redesign-hint-mechanism/参考.md` §3)
+ * - **戻り値型**: `CollectedPreview`。 既存 [CollectedPreviewIrBuilder] を IR 側で再利用できる
+ * - **Predicate walk のタイミング**: cache loader 内で `predicateBasedProvider` を walk すると
+ *   Kotlin 2.3.21 frontend resolution cycle に当たる。 [getTopLevelCallableIds] 内で
+ *   遅延評価すること
+ * - **Visibility**: `Visibilities.Public` 必須。 cross-module から `referenceFunctions(...)`
+ *   で発見されるため
+ * - **`ignore = true` の取り扱い**: `@ComposePreviewLabOption(ignore = true)` は FIR phase で
+ *   annotation argument を読むのが安定しないため、 ここでは hint emit 時には filter せず、
+ *   IR 側 / consumer 側で除外する方針 (TODO: cross-module で ignore preview が露出しない
+ *   形にする follow-up が必要)
+ *
+ * Pattern adapted from Metro's
+ * [ContributionHintFirGenerator](https://github.com/ZacSweers/metro/blob/main/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributionHintFirGenerator.kt).
+ */
+internal class PreviewHintFirGeneratorV2(session: FirSession) : FirDeclarationGenerationExtension(session) {
+
+    /**
+     * `@Preview` 関数を発見するための predicate。 CMP / Android 両方の `@Preview` annotation を
+     * 対象にする。
+     */
+    private val previewPredicate: LookupPredicate = LookupPredicate.create {
+        annotated(
+            PreviewLabFirBuiltIns.CMP_PREVIEW_ANNOTATION_FQN,
+            PreviewLabFirBuiltIns.ANDROID_PREVIEW_ANNOTATION_FQN,
+        )
+    }
+
+    /**
+     * このセッションで発見された `@Preview` 関数群と対応する hint 関数の `CallableId`。
+     * `getTopLevelCallableIds()` で初めて触られた時点で walk する (cache loader 内で walk
+     * しない)。
+     */
+    private val hintCallableIds: List<CallableId> by lazy { computeHintCallableIds() }
+
+    override fun FirDeclarationPredicateRegistrar.registerPredicates() {
+        register(previewPredicate)
+    }
+
+    override fun getTopLevelCallableIds(): Set<CallableId> = hintCallableIds.toSet()
+
+    override fun hasPackage(packageFqName: FqName): Boolean = packageFqName == PreviewLabFirBuiltIns.HINT_PACKAGE_V2
+
+    /**
+     * Hint 関数 stub を生成する。
+     *
+     * `callableId` がこの session で発見された hint の 1 つに該当する場合、 戻り値型
+     * `CollectedPreview` で `public` な top-level 関数を 1 つ emit する。
+     *
+     * **Emitted Kotlin (semantically equivalent)**:
+     * ```kotlin
+     * public fun previewHint_<hash>(): CollectedPreview
+     * ```
+     *
+     * Body は emit しない (FIR は body を持てない)。 [Keys.PreviewLabHintV2] origin が
+     * IR 側 [me.tbsten.compose.preview.lab.compiler.ir.PreviewHintIrBodyFillerV2] への signal で、
+     * IR pass で `CollectedPreview(...)` constructor 呼び出しを return する body が埋まる。
+     */
+    override fun generateFunctions(callableId: CallableId, context: MemberGenerationContext?): List<FirNamedFunctionSymbol> {
+        if (callableId.packageName != PreviewLabFirBuiltIns.HINT_PACKAGE_V2) return emptyList()
+        if (callableId !in hintCallableIds) return emptyList()
+
+        val collectedPreviewSymbol = session.symbolProvider
+            .getClassLikeSymbolByClassId(PreviewLabFirBuiltIns.COLLECTED_PREVIEW_CLASS_ID)
+            ?: return emptyList()
+        val collectedPreviewType = collectedPreviewSymbol.constructType(emptyArray())
+
+        val fileName = "${callableId.callableName.asString()}.kt"
+        val function = createTopLevelFunction(
+            Keys.PreviewLabHintV2,
+            callableId,
+            collectedPreviewType,
+            fileName,
+        ) {
+            visibility = Visibilities.Public
+        }
+
+        return listOf(function.symbol)
+    }
+
+    /**
+     * Predicate walk + 各 `@Preview` 関数から hint 関数 `CallableId` を計算する。
+     *
+     * `getTopLevelCallableIds()` 経由で初めて触られた時点で評価される (lazy)。
+     */
+    private fun computeHintCallableIds(): List<CallableId> {
+        val symbols = session.predicateBasedProvider.getSymbolsByPredicate(previewPredicate)
+        return symbols
+            .filterIsInstance<FirNamedFunctionSymbol>()
+            .filter { it.callableId.classId == null }
+            .map { symbol ->
+                val callableId = symbol.callableId
+                val packageName = callableId.packageName.asString()
+                val simpleName = callableId.callableName.asString()
+                val sourceFqn = if (packageName.isEmpty()) simpleName else "$packageName.$simpleName"
+                val hash = computeSourceFqnHash(sourceFqn)
+                CallableId(
+                    PreviewLabFirBuiltIns.HINT_PACKAGE_V2,
+                    Name.identifier("${PreviewLabFirBuiltIns.PreviewHintV2Prefix}$hash"),
+                )
+            }
+            .distinct()
+    }
+}

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewHintFirGeneratorV2.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewHintFirGeneratorV2.kt
@@ -6,6 +6,7 @@ package me.tbsten.compose.preview.lab.compiler.fir
 
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationGenerationExtension
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
 import org.jetbrains.kotlin.fir.extensions.MemberGenerationContext
@@ -14,7 +15,10 @@ import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
 import org.jetbrains.kotlin.fir.plugin.createTopLevelFunction
 import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.lazyResolveToPhase
+import org.jetbrains.kotlin.fir.types.classId
 import org.jetbrains.kotlin.fir.types.constructType
+import org.jetbrains.kotlin.fir.types.isMarkedNullable
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
@@ -127,7 +131,10 @@ internal class PreviewHintFirGeneratorV2(session: FirSession) : FirDeclarationGe
             ?: return emptyList()
         val collectedPreviewType = collectedPreviewSymbol.constructType(emptyArray())
 
-        val fileName = "${callableId.callableName.asString()}.kt"
+        // 同 package に user-side の `previewHint_<hash>` 同名トップレベル関数があった場合に
+        // file facade class が衝突しないよう、 plugin 生成 file 名には `__Hint` suffix を付ける。
+        // class 名は `PreviewHint_<hash>__HintKt` になる。
+        val fileName = "${callableId.callableName.asString()}__Hint.kt"
         val function = createTopLevelFunction(
             Keys.PreviewLabHintV2,
             callableId,
@@ -155,12 +162,32 @@ internal class PreviewHintFirGeneratorV2(session: FirSession) : FirDeclarationGe
                 val packageName = callableId.packageName.asString()
                 val simpleName = callableId.callableName.asString()
                 val sourceFqn = if (packageName.isEmpty()) simpleName else "$packageName.$simpleName"
-                val hash = computeSourceFqnHash(sourceFqn)
+                val parameterTypeFqns = symbol.parameterTypeFqnsForHash()
+                val canonicalKey = buildPreviewHintCanonicalKey(sourceFqn, parameterTypeFqns)
+                val hash = computeHintHash(canonicalKey)
                 CallableId(
                     PreviewLabFirBuiltIns.HINT_PACKAGE_V2,
                     Name.identifier("${PreviewLabFirBuiltIns.PreviewHintV2Prefix}$hash"),
                 )
             }
             .distinct()
+    }
+
+    /**
+     * `@Preview` 関数の value parameter type を hint canonical key 用の FQN リストに変換する。
+     *
+     * 同名 overload (`fun MyButton()` と `fun MyButton(text: String)`) を区別するため、
+     * 各パラメータの type FQN を含めて hash 入力を作る。 parameter type の resolve には
+     * TYPES phase が必要なので [lazyResolveToPhase] で進める。
+     *
+     * **Format**: 各 type は `<classId>` (nullable なら `?` を suffix)。 unknown は `?` を返す。
+     */
+    private fun FirNamedFunctionSymbol.parameterTypeFqnsForHash(): List<String> {
+        lazyResolveToPhase(FirResolvePhase.TYPES)
+        return valueParameterSymbols.map { paramSymbol ->
+            val coneType = paramSymbol.resolvedReturnTypeRef.coneType
+            val classFqn = coneType.classId?.asFqNameString() ?: "?"
+            if (coneType.isMarkedNullable) "$classFqn?" else classFqn
+        }
     }
 }

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewLabFirBuiltIns.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewLabFirBuiltIns.kt
@@ -62,6 +62,20 @@ internal class PreviewLabFirBuiltIns(session: FirSession, val config: PluginConf
 
         /** Auto-provider function name prefix; suffix is the per-module hash that matches the marker class. */
         const val AutoProviderPrefix: String = "previewLabAutoProvider_"
+
+        // -------------------- per-declaration hint (Metro 風) 用の identifier --------------------
+
+        /** Per-declaration hint 関数が住む package。 旧モジュール集約 marker (`exports`) とは別 package で併存中の交錯を避ける。 */
+        val HINT_PACKAGE_V2: FqName = FqName("me.tbsten.compose.preview.lab.hints")
+
+        /** Per-declaration hint 関数名 prefix。 suffix は `sha256(sourceFqn)` の base-36 8 文字。 */
+        const val PreviewHintV2Prefix: String = "previewHint_"
+
+        /** CMP / Android `@Preview` annotation FQN (predicate registration 用)。 */
+        val CMP_PREVIEW_ANNOTATION_FQN: FqName =
+            FqName("org.jetbrains.compose.ui.tooling.preview.Preview")
+        val ANDROID_PREVIEW_ANNOTATION_FQN: FqName =
+            FqName("androidx.compose.ui.tooling.preview.Preview")
     }
 }
 

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewLabFirExtensionRegistrar.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewLabFirExtensionRegistrar.kt
@@ -25,6 +25,7 @@ class PreviewLabFirExtensionRegistrar(private val config: PluginConfig) : FirExt
         +::PreviewLabFirStatusTransformerExtension
         if (CompatContext.load().supportsKlibCrossModuleHint()) {
             +::PreviewLabHintFirGenerator
+            +::PreviewHintFirGeneratorV2
         }
     }
 }

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/SourceFqnHash.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/SourceFqnHash.kt
@@ -1,0 +1,29 @@
+package me.tbsten.compose.preview.lab.compiler.fir
+
+import java.security.MessageDigest
+
+/**
+ * Per-declaration hint 関数名 suffix を `@Preview` の source FQN から導出する hash 関数。
+ *
+ * 「モジュール集約 marker」 を per-module で hash する [computeModuleHash] とは別物。
+ * per-declaration 方式では「`@Preview` 1 個 = hint 1 個」 で入力は **sourceFqn のみ**。
+ * projectRootPath / moduleName を入力に含めると同じ `@Preview` の hint 関数名が build 環境で
+ * 変動し、 incremental compile / 再現可能ビルド両方を破壊するため含めない。
+ *
+ * 同 FQN cross-artifact collision (e.g. 別 artifact に `com.example.Foo` が同名で存在) は
+ * **user 側の名前空間管理で解決する受容済み edge case** とする (`.local/redesign-hint-mechanism/参考.md`
+ * §3 参照)。
+ *
+ * **Sample call**: `computeSourceFqnHash("uiLib.button.MyButton")`
+ *
+ * **Result**: `"a3k9z2x1"` 程度の base-36 8 文字 ([computeModuleHash] と同じ format)
+ *
+ * SHA-256 → 先頭 8 byte (64 bit) → base-36 で encode → 末尾 8 文字。 この格子は約 41 bit 強で、
+ * 名前空間サイズに対する collision 確率は実用上十分小さい。
+ */
+internal fun computeSourceFqnHash(sourceFqn: String): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(sourceFqn.toByteArray(Charsets.UTF_8))
+    val truncated = java.math.BigInteger(1, digest.copyOf(8))
+    val encoded = truncated.toString(36)
+    return encoded.takeLast(8).padStart(8, '0')
+}

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/SourceFqnHash.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/SourceFqnHash.kt
@@ -3,27 +3,51 @@ package me.tbsten.compose.preview.lab.compiler.fir
 import java.security.MessageDigest
 
 /**
- * Per-declaration hint 関数名 suffix を `@Preview` の source FQN から導出する hash 関数。
+ * Per-declaration hint 関数名 suffix を `@Preview` の canonical signature key から導出する
+ * hash 関数。
  *
  * 「モジュール集約 marker」 を per-module で hash する [computeModuleHash] とは別物。
- * per-declaration 方式では「`@Preview` 1 個 = hint 1 個」 で入力は **sourceFqn のみ**。
+ * per-declaration 方式では「`@Preview` 1 個 = hint 1 個」 で入力は **canonical key のみ**。
  * projectRootPath / moduleName を入力に含めると同じ `@Preview` の hint 関数名が build 環境で
  * 変動し、 incremental compile / 再現可能ビルド両方を破壊するため含めない。
  *
- * 同 FQN cross-artifact collision (e.g. 別 artifact に `com.example.Foo` が同名で存在) は
- * **user 側の名前空間管理で解決する受容済み edge case** とする (`.local/redesign-hint-mechanism/参考.md`
- * §3 参照)。
+ * 同 canonical key cross-artifact collision (e.g. 別 artifact に同 FQN + 同 signature の
+ * `@Preview` が存在) は **user 側の名前空間管理で解決する受容済み edge case** とする
+ * (`.local/redesign-hint-mechanism/参考.md` §3 参照)。
  *
- * **Sample call**: `computeSourceFqnHash("uiLib.button.MyButton")`
+ * **Sample call**: `computeHintHash("uiLib.button.MyButton()")`
  *
  * **Result**: `"a3k9z2x1"` 程度の base-36 8 文字 ([computeModuleHash] と同じ format)
  *
  * SHA-256 → 先頭 8 byte (64 bit) → base-36 で encode → 末尾 8 文字。 この格子は約 41 bit 強で、
  * 名前空間サイズに対する collision 確率は実用上十分小さい。
+ *
+ * # Canonical key の format
+ *
+ * 同名 overload (例: 同 package に `fun MyButton()` と `fun MyButton(text: String)` があるケース)
+ * を区別するため、 caller は **canonical key として `<sourceFqn>(<paramTypeFqns>)` 形式** を
+ * 渡すこと:
+ *
+ * - sourceFqn: `<package>.<simpleName>`
+ * - paramTypeFqns: 各パラメータの type FQN を `,` で連結。 nullability は `?` を suffix
+ *   (例: `kotlin.String?`)
+ *
+ * [buildPreviewHintCanonicalKey] が FIR / IR それぞれの API から canonical key を構築する
+ * helper。
  */
-internal fun computeSourceFqnHash(sourceFqn: String): String {
-    val digest = MessageDigest.getInstance("SHA-256").digest(sourceFqn.toByteArray(Charsets.UTF_8))
+internal fun computeHintHash(canonicalKey: String): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(canonicalKey.toByteArray(Charsets.UTF_8))
     val truncated = java.math.BigInteger(1, digest.copyOf(8))
     val encoded = truncated.toString(36)
     return encoded.takeLast(8).padStart(8, '0')
 }
+
+/**
+ * `<sourceFqn>(<paramTypeFqn1>,<paramTypeFqn2>,...)` という canonical key を組み立てる。
+ * FIR / IR で同じ key を生成するために `parameterTypeFqns` の生成方法を caller 側で揃えること。
+ *
+ * **Sample**: `buildPreviewHintCanonicalKey("uiLib.MyButton", emptyList())` → `"uiLib.MyButton()"`
+ * **Sample**: `buildPreviewHintCanonicalKey("uiLib.MyButton", listOf("kotlin.String"))` → `"uiLib.MyButton(kotlin.String)"`
+ */
+internal fun buildPreviewHintCanonicalKey(sourceFqn: String, parameterTypeFqns: List<String>): String =
+    "$sourceFqn(${parameterTypeFqns.joinToString(",")})"

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewHintIrBodyFillerV2.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewHintIrBodyFillerV2.kt
@@ -5,15 +5,19 @@ package me.tbsten.compose.preview.lab.compiler.ir
 import me.tbsten.compose.preview.lab.compiler.compat.CompatContext
 import me.tbsten.compose.preview.lab.compiler.fir.Keys
 import me.tbsten.compose.preview.lab.compiler.fir.PreviewLabFirBuiltIns
-import me.tbsten.compose.preview.lab.compiler.fir.computeSourceFqnHash
+import me.tbsten.compose.preview.lab.compiler.fir.buildPreviewHintCanonicalKey
+import me.tbsten.compose.preview.lab.compiler.fir.computeHintHash
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irBlockBody
 import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.classFqName
+import org.jetbrains.kotlin.ir.types.isMarkedNullable
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 
@@ -112,12 +116,16 @@ internal class PreviewHintIrBodyFillerV2(
 }
 
 /**
- * `@Preview` annotated top-level 関数を moduleFragment から走査し、 sourceFqn の hash を key
- * とした [PreviewFunctionInfo] map を構築する。
+ * `@Preview` annotated top-level 関数を moduleFragment から走査し、 canonical key の hash を
+ * key とした [PreviewFunctionInfo] map を構築する。
  *
  * `ignore = true` の preview も含めることで、 [PreviewHintFirGeneratorV2] が emit した
  * すべての hint declaration に body を埋められるようにする。 ignore filter は consumer 側
  * で行う想定 (TODO: cross-module で ignore preview が露出しない形にする follow-up)。
+ *
+ * Canonical key は同名 overload (`fun MyButton()` と `fun MyButton(text: String)`) を
+ * 区別するため、 sourceFqn + parameter type FQN を含む形で組み立てる。 FIR generator と
+ * 同じロジックを使う必要があるため [buildPreviewHintCanonicalKey] を共有する。
  *
  * **Sample entry**: `"a3k9z2x1" → PreviewFunctionInfo(function = fun MyButton(), id = "uiLib.button.MyButton", ...)`
  */
@@ -125,6 +133,21 @@ internal fun buildPreviewByHashMap(previews: List<PreviewFunctionInfo>): Map<Str
     for (preview in previews) {
         val sourceFqn = preview.function.kotlinFqName.asString()
         if (sourceFqn.isEmpty()) continue
-        put(computeSourceFqnHash(sourceFqn), preview)
+        val parameterTypeFqns = preview.function.parameterTypeFqnsForHash()
+        val canonicalKey = buildPreviewHintCanonicalKey(sourceFqn, parameterTypeFqns)
+        put(computeHintHash(canonicalKey), preview)
     }
 }
+
+/**
+ * IR `IrSimpleFunction` の value parameter type を hint canonical key 用の FQN リストに変換する。
+ * FIR side [me.tbsten.compose.preview.lab.compiler.fir.PreviewHintFirGeneratorV2] と同じ format で
+ * 揃える必要がある (nullable は `?` suffix、 unknown は `?` 単体)。
+ */
+private fun IrSimpleFunction.parameterTypeFqnsForHash(): List<String> = parameters
+    .filter { it.kind == IrParameterKind.Regular }
+    .map { param ->
+        val type = param.type
+        val classFqn = type.classFqName?.asString() ?: "?"
+        if (type.isMarkedNullable()) "$classFqn?" else classFqn
+    }

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewHintIrBodyFillerV2.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewHintIrBodyFillerV2.kt
@@ -1,0 +1,130 @@
+@file:OptIn(UnsafeDuringIrConstructionAPI::class)
+
+package me.tbsten.compose.preview.lab.compiler.ir
+
+import me.tbsten.compose.preview.lab.compiler.compat.CompatContext
+import me.tbsten.compose.preview.lab.compiler.fir.Keys
+import me.tbsten.compose.preview.lab.compiler.fir.PreviewLabFirBuiltIns
+import me.tbsten.compose.preview.lab.compiler.fir.computeSourceFqnHash
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.irBlockBody
+import org.jetbrains.kotlin.ir.builders.irReturn
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.util.kotlinFqName
+import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
+
+/**
+ * [me.tbsten.compose.preview.lab.compiler.fir.PreviewHintFirGeneratorV2] が emit した
+ * `previewHint_<hash>(): CollectedPreview` stub の body を埋める。 FIR は body を持てないので
+ * IR pass で `CollectedPreview(...)` constructor 呼び出しを `irReturn` する形に書き換える。
+ *
+ * **Hint function**
+ *
+ * Before (FIR から渡る):
+ * ```kotlin
+ * public fun previewHint_<hash>(): CollectedPreview  // body == null
+ * ```
+ *
+ * After (本 transformer が書き換え):
+ * ```kotlin
+ * public fun previewHint_<hash>(): CollectedPreview = CollectedPreview(
+ *     id = "uiLib.button.MyButton",
+ *     displayName = "uiLib.button.MyButton",
+ *     filePath = "uiLib/src/.../MyButton.kt",
+ *     startLineNumber = 5,
+ *     endLineNumber = 9,
+ *     code = "{ ... }",
+ *     kdoc = null,
+ *     content = @Composable { uiLib.button.MyButton() },
+ * )
+ * ```
+ *
+ * # 設計ポイント
+ *
+ * - **Hint と `@Preview` の照合**: hint 関数名 `previewHint_<hash>` から hash を取り出し、
+ *   IR module 内の `@Preview` 関数の sourceFqn を hash した値と突き合わせて元関数を特定する。
+ *   FIR generator と IR side で同一の [computeSourceFqnHash] を使うので一意に照合できる
+ * - **`CollectedPreview` 構築**: 既存 [CollectedPreviewIrBuilder.buildCollectedPreviewCall] を
+ *   そのまま再利用する。 旧モジュール集約 hint
+ *   (`previewLabAutoProvider_<hash>(): List<CollectedPreview>`) も同じ builder で個々の
+ *   `CollectedPreview` を構築しているので、 hint 関数の戻り値の差は「単体 vs List」 だけ
+ * - **`@ComposePreviewLabOption(ignore = true)` の取り扱い**: hint emit 自体は ignore=true でも
+ *   行うため、 IR 側でも `previews` (filter 済み) ではなく moduleFragment 全体の `@Preview`
+ *   関数を直接走査して PreviewFunctionInfo を構築する。 そうしないと ignore=true の hint が
+ *   orphan (body=null) になり JVM backend assert に当たる
+ */
+internal class PreviewHintIrBodyFillerV2(
+    private val pluginContext: IrPluginContext,
+    private val compatContext: CompatContext,
+    private val previewsByHash: Map<String, PreviewFunctionInfo>,
+) : IrElementTransformerVoid() {
+
+    /** Lazily 構築。 既存 builder を再利用して `CollectedPreview(...)` IR を生成する。 */
+    private val collectedPreviewBuilder by lazy {
+        CollectedPreviewIrBuilder(pluginContext, compatContext)
+    }
+
+    /**
+     * Hint 関数の body を `CollectedPreview(...)` constructor 呼び出しの `irReturn` に書き換える。
+     *
+     * `Keys.PreviewLabHintV2` origin の関数のみを対象にする。 元 `@Preview` 関数は hint 関数名
+     * `previewHint_<hash>` の hash 部分から特定する。
+     *
+     * **Before**:
+     * ```kotlin
+     * public fun previewHint_a3k9z2x1(): CollectedPreview  // body == null
+     * ```
+     *
+     * **After** (semantically):
+     * ```kotlin
+     * public fun previewHint_a3k9z2x1(): CollectedPreview = CollectedPreview(
+     *     id = "uiLib.button.MyButton", ..., content = @Composable { uiLib.button.MyButton() },
+     * )
+     * ```
+     */
+    override fun visitSimpleFunction(declaration: IrSimpleFunction): IrStatement {
+        if (declaration.body != null) return super.visitSimpleFunction(declaration)
+        if (!declaration.isHintV2()) return super.visitSimpleFunction(declaration)
+
+        val hash = declaration.name.asString()
+            .removePrefix(PreviewLabFirBuiltIns.PreviewHintV2Prefix)
+        val previewInfo = previewsByHash[hash] ?: return super.visitSimpleFunction(declaration)
+
+        val builder = DeclarationIrBuilder(pluginContext, declaration.symbol)
+        val collectedPreviewExpr = collectedPreviewBuilder.buildCollectedPreviewCall(
+            preview = previewInfo,
+            builder = builder,
+            parent = declaration,
+        )
+        declaration.body = builder.irBlockBody { +irReturn(collectedPreviewExpr) }
+
+        return super.visitSimpleFunction(declaration)
+    }
+
+    private fun IrSimpleFunction.isHintV2(): Boolean {
+        val origin = origin
+        return origin is IrDeclarationOrigin.GeneratedByPlugin && origin.pluginKey === Keys.PreviewLabHintV2
+    }
+}
+
+/**
+ * `@Preview` annotated top-level 関数を moduleFragment から走査し、 sourceFqn の hash を key
+ * とした [PreviewFunctionInfo] map を構築する。
+ *
+ * `ignore = true` の preview も含めることで、 [PreviewHintFirGeneratorV2] が emit した
+ * すべての hint declaration に body を埋められるようにする。 ignore filter は consumer 側
+ * で行う想定 (TODO: cross-module で ignore preview が露出しない形にする follow-up)。
+ *
+ * **Sample entry**: `"a3k9z2x1" → PreviewFunctionInfo(function = fun MyButton(), id = "uiLib.button.MyButton", ...)`
+ */
+internal fun buildPreviewByHashMap(previews: List<PreviewFunctionInfo>): Map<String, PreviewFunctionInfo> = buildMap {
+    for (preview in previews) {
+        val sourceFqn = preview.function.kotlinFqName.asString()
+        if (sourceFqn.isEmpty()) continue
+        put(computeSourceFqnHash(sourceFqn), preview)
+    }
+}

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewLabIrGenerationExtension.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewLabIrGenerationExtension.kt
@@ -51,6 +51,16 @@ class PreviewLabIrGenerationExtension(
                 moduleFragment,
                 PreviewLabHintIrBodyFiller(pluginContext, compatContext, previews, config),
             )
+            // Per-declaration hint (Metro 風) 用の body filler。 旧モジュール集約 hint と
+            // 別 origin (`Keys.PreviewLabHintV2`) なので独立 transform として走る。
+            // hint emit 側で ignore=true を filter していないため、 body fill 用の lookup
+            // は ignore=true も含めて構築する必要がある。
+            val previewsIncludingIgnored = collectPreviewsIncludingIgnored(moduleFragment)
+            val previewsByHash = buildPreviewByHashMap(previewsIncludingIgnored)
+            compatContext.transformModuleFragment(
+                moduleFragment,
+                PreviewHintIrBodyFillerV2(pluginContext, compatContext, previewsByHash),
+            )
         }
 
         // Auto-provider emission.
@@ -91,6 +101,22 @@ class PreviewLabIrGenerationExtension(
     }
 
     /**
+     * `@Preview` annotated 関数を `@ComposePreviewLabOption(ignore = true)` も含めて全て収集する。
+     * Per-declaration hint body filler は ignore=true でも body を埋める必要があるため、
+     * 通常の [collectPreviews] (ignore filter 済み) ではなく本関数を使う。
+     */
+    private fun collectPreviewsIncludingIgnored(moduleFragment: IrModuleFragment): List<PreviewFunctionInfo> {
+        val result = mutableListOf<PreviewFunctionInfo>()
+        for (file in moduleFragment.files) {
+            for (decl in file.declarations) {
+                if (decl !is IrSimpleFunction) continue
+                buildPreviewInfoOrNull(decl, includeIgnored = true)?.let { result.add(it) }
+            }
+        }
+        return result
+    }
+
+    /**
      * Builds a [PreviewFunctionInfo] for a `@Preview`-annotated top-level function, or returns
      * null if the function should be skipped (not annotated, or `ignore = true`).
      *
@@ -118,12 +144,20 @@ class PreviewLabIrGenerationExtension(
      * Template placeholders `{{package}}`, `{{simpleName}}`, `{{qualifiedName}}` are resolved
      * in both `displayName` and `id`.
      */
-    private fun buildPreviewInfo(func: IrSimpleFunction): PreviewFunctionInfo? {
+    private fun buildPreviewInfo(func: IrSimpleFunction): PreviewFunctionInfo? =
+        buildPreviewInfoOrNull(func, includeIgnored = false)
+
+    /**
+     * `buildPreviewInfo` の internal 版。 [includeIgnored] = true の場合、 `ignore = true` でも
+     * 除外せず [PreviewFunctionInfo] を返す。 per-declaration hint body filler が
+     * `@ComposePreviewLabOption(ignore = true)` の preview にも hint body を埋めるために使う。
+     */
+    internal fun buildPreviewInfoOrNull(func: IrSimpleFunction, includeIgnored: Boolean): PreviewFunctionInfo? {
         if (!func.hasAnnotationCompat(CMP_PREVIEW_FQ) && !func.hasAnnotationCompat(ANDROID_PREVIEW_FQ)) return null
 
         val optionAnno = func.getAnnotationCompat(CPL_OPTION_FQ)
         val ignore = (optionAnno?.arguments?.getOrNull(1) as? IrConst)?.value as? Boolean ?: false
-        if (ignore) return null
+        if (ignore && !includeIgnored) return null
 
         val packageName = func.file.packageFqName.asString()
         val simpleName = func.name.asString()

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/PreviewHintV2EmissionTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/PreviewHintV2EmissionTest.kt
@@ -5,8 +5,10 @@ import com.tschuchort.compiletesting.SourceFile
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldExist
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import me.tbsten.compose.preview.lab.compiler.CompilerPluginTestBase
-import me.tbsten.compose.preview.lab.compiler.fir.computeSourceFqnHash
+import me.tbsten.compose.preview.lab.compiler.fir.buildPreviewHintCanonicalKey
+import me.tbsten.compose.preview.lab.compiler.fir.computeHintHash
 
 /**
  * Per-declaration hint generator (Metro 風) が `@Preview` 1 個に対し
@@ -21,7 +23,7 @@ class PreviewHintV2EmissionTest :
         val base = CompilerPluginTestBase()
 
         val testKotlinVersion = System.getProperty("test.kotlin.version") ?: "2.3.21"
-        val supports = testKotlinVersion.compareTo("2.3.21") >= 0 || testKotlinVersion.startsWith("2.4")
+        val supports = testKotlinVersion.isAtLeast(2, 3, 21)
 
         test("@Preview 1 個 → previewHint_<hash> が 1 個 emit される")
             .config(enabled = supports) {
@@ -38,9 +40,11 @@ class PreviewHintV2EmissionTest :
                 )
                 result.exitCode shouldBe KotlinCompilation.ExitCode.OK
 
-                val expectedHash = computeSourceFqnHash("test.source.MyButton")
-                // file facade class name は file 名の先頭を capitalize: previewHint_<hash>.kt → PreviewHint_<hash>Kt.class
-                val expectedClassFile = "me/tbsten/compose/preview/lab/hints/PreviewHint_${expectedHash}Kt.class"
+                val expectedHash = computeHintHash(
+                    buildPreviewHintCanonicalKey("test.source.MyButton", emptyList()),
+                )
+                // file 名 `previewHint_<hash>__Hint.kt` → file facade class `PreviewHint_<hash>__HintKt`
+                val expectedClassFile = "me/tbsten/compose/preview/lab/hints/PreviewHint_${expectedHash}__HintKt.class"
 
                 val classFiles = result.outputDirectory.walkTopDown()
                     .filter { it.isFile && it.name.endsWith(".class") }
@@ -65,9 +69,11 @@ class PreviewHintV2EmissionTest :
                 )
                 result.exitCode shouldBe KotlinCompilation.ExitCode.OK
 
-                val expectedHash = computeSourceFqnHash("test.source.MyButton")
+                val expectedHash = computeHintHash(
+                    buildPreviewHintCanonicalKey("test.source.MyButton", emptyList()),
+                )
                 val hintFacade = result.classLoader
-                    .loadClass("me.tbsten.compose.preview.lab.hints.PreviewHint_${expectedHash}Kt")
+                    .loadClass("me.tbsten.compose.preview.lab.hints.PreviewHint_${expectedHash}__HintKt")
                 val hintMethod = hintFacade.getMethod("previewHint_$expectedHash")
 
                 // hint() を invoke すると CollectedPreview インスタンスが返る
@@ -82,7 +88,7 @@ class PreviewHintV2EmissionTest :
                 displayName shouldBe "test.source.MyButton"
             }
 
-        test("@Preview が複数あれば hint が複数 emit される")
+        test("@Preview が複数あれば hint が複数 emit され、 hash は別 (overload も signature で区別)")
             .config(enabled = supports) {
                 val result = base.compile(
                     SourceFile.kotlin(
@@ -100,9 +106,10 @@ class PreviewHintV2EmissionTest :
                 )
                 result.exitCode shouldBe KotlinCompilation.ExitCode.OK
 
-                val firstHash = computeSourceFqnHash("test.source.First")
-                val secondHash = computeSourceFqnHash("test.source.Second")
-                firstHash shouldBe firstHash // sanity (deterministic)
+                val firstHash = computeHintHash(buildPreviewHintCanonicalKey("test.source.First", emptyList()))
+                val secondHash = computeHintHash(buildPreviewHintCanonicalKey("test.source.Second", emptyList()))
+                // 別 sourceFqn なので別 hash → 別 hint 関数として共存
+                firstHash shouldNotBe secondHash
 
                 val classFiles = result.outputDirectory.walkTopDown()
                     .filter { it.isFile && it.name.endsWith(".class") }
@@ -110,18 +117,58 @@ class PreviewHintV2EmissionTest :
                     .toList()
 
                 classFiles shouldExist {
-                    it == "me/tbsten/compose/preview/lab/hints/PreviewHint_${firstHash}Kt.class"
+                    it == "me/tbsten/compose/preview/lab/hints/PreviewHint_${firstHash}__HintKt.class"
                 }
                 classFiles shouldExist {
-                    it == "me/tbsten/compose/preview/lab/hints/PreviewHint_${secondHash}Kt.class"
+                    it == "me/tbsten/compose/preview/lab/hints/PreviewHint_${secondHash}__HintKt.class"
                 }
             }
 
-        test("同じ source FQN の hash は projectRootPath に依存せず再現可能")
+        test("同名 overload を canonical key の signature で区別する (hash unit-level)") {
+            // hint canonical key 自体が parameter signature を含むので、 同 sourceFqn でも
+            // 異なる signature なら異なる hash になることを確認。
+            // (parameterized `@Preview` を実際に compile した end-to-end test は orthogonal な
+            //  「lambda body が param 付き関数を call できない」 課題があるため別 ticket で扱う)
+            val noArgHash = computeHintHash(buildPreviewHintCanonicalKey("test.source.MyButton", emptyList()))
+            val withStringArgHash = computeHintHash(
+                buildPreviewHintCanonicalKey("test.source.MyButton", listOf("kotlin.String")),
+            )
+            val withIntArgHash = computeHintHash(
+                buildPreviewHintCanonicalKey("test.source.MyButton", listOf("kotlin.Int")),
+            )
+            val withNullableStringArgHash = computeHintHash(
+                buildPreviewHintCanonicalKey("test.source.MyButton", listOf("kotlin.String?")),
+            )
+            noArgHash shouldNotBe withStringArgHash
+            withStringArgHash shouldNotBe withIntArgHash
+            withStringArgHash shouldNotBe withNullableStringArgHash
+        }
+
+        test("hash 関数が canonical key で再現可能 (projectRootPath 非依存)")
             .config(enabled = supports) {
-                // hash 関数自体の reproducibility を verify (compile 越しではなく直接)
-                val a = computeSourceFqnHash("uiLib.button.MyButton")
-                val b = computeSourceFqnHash("uiLib.button.MyButton")
+                val key = buildPreviewHintCanonicalKey("uiLib.button.MyButton", emptyList())
+                val a = computeHintHash(key)
+                val b = computeHintHash(key)
                 a shouldBe b
             }
     })
+
+/**
+ * `"2.3.9"` 等の lexicographic 比較で誤って `>= 2.3.21` 判定される問題を避けるため、
+ * `MAJOR.MINOR.PATCH` を numeric 比較する簡易 helper。
+ *
+ * **Sample**: `"2.3.21".isAtLeast(2, 3, 21)` → `true`、 `"2.3.9".isAtLeast(2, 3, 21)` → `false`、
+ * `"2.4.0".isAtLeast(2, 3, 21)` → `true`、 `"2.3.21-Beta1".isAtLeast(2, 3, 21)` → `true`
+ * (suffix は無視)。
+ */
+private fun String.isAtLeast(major: Int, minor: Int, patch: Int): Boolean {
+    val parts = substringBefore('-').split('.')
+    val v0 = parts.getOrNull(0)?.toIntOrNull() ?: 0
+    val v1 = parts.getOrNull(1)?.toIntOrNull() ?: 0
+    val v2 = parts.getOrNull(2)?.toIntOrNull() ?: 0
+    return when {
+        v0 != major -> v0 > major
+        v1 != minor -> v1 > minor
+        else -> v2 >= patch
+    }
+}

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/PreviewHintV2EmissionTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/PreviewHintV2EmissionTest.kt
@@ -1,0 +1,127 @@
+package me.tbsten.compose.preview.lab.compiler.feature
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldExist
+import io.kotest.matchers.shouldBe
+import me.tbsten.compose.preview.lab.compiler.CompilerPluginTestBase
+import me.tbsten.compose.preview.lab.compiler.fir.computeSourceFqnHash
+
+/**
+ * Per-declaration hint generator (Metro 風) が `@Preview` 1 個に対し
+ * `previewHint_<sha256(sourceFqn)>(): CollectedPreview` を 1 個 emit し、 IR で body に
+ * `CollectedPreview(...)` constructor 呼び出しを埋め込んでいることを検証する。
+ *
+ * **Skipped on Kotlin < 2.3.21**: 旧モジュール集約 hint generator と同じ version gate に従う
+ * ([CompatContext.supportsKlibCrossModuleHint][me.tbsten.compose.preview.lab.compiler.compat.CompatContext.supportsKlibCrossModuleHint])。
+ */
+class PreviewHintV2EmissionTest :
+    FunSpec({
+        val base = CompilerPluginTestBase()
+
+        val testKotlinVersion = System.getProperty("test.kotlin.version") ?: "2.3.21"
+        val supports = testKotlinVersion.compareTo("2.3.21") >= 0 || testKotlinVersion.startsWith("2.4")
+
+        test("@Preview 1 個 → previewHint_<hash> が 1 個 emit される")
+            .config(enabled = supports) {
+                val result = base.compile(
+                    SourceFile.kotlin(
+                        "Previews.kt",
+                        """
+                        package test.source
+
+                        @org.jetbrains.compose.ui.tooling.preview.Preview
+                        fun MyButton() {}
+                        """,
+                    ),
+                )
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                val expectedHash = computeSourceFqnHash("test.source.MyButton")
+                // file facade class name は file 名の先頭を capitalize: previewHint_<hash>.kt → PreviewHint_<hash>Kt.class
+                val expectedClassFile = "me/tbsten/compose/preview/lab/hints/PreviewHint_${expectedHash}Kt.class"
+
+                val classFiles = result.outputDirectory.walkTopDown()
+                    .filter { it.isFile && it.name.endsWith(".class") }
+                    .map { it.relativeTo(result.outputDirectory).path }
+                    .toList()
+
+                classFiles shouldExist { it == expectedClassFile }
+            }
+
+        test("hint 関数 invoke で CollectedPreview が返り、 metadata が埋まっている")
+            .config(enabled = supports) {
+                val result = base.compile(
+                    SourceFile.kotlin(
+                        "Previews.kt",
+                        """
+                        package test.source
+
+                        @org.jetbrains.compose.ui.tooling.preview.Preview
+                        fun MyButton() {}
+                        """,
+                    ),
+                )
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                val expectedHash = computeSourceFqnHash("test.source.MyButton")
+                val hintFacade = result.classLoader
+                    .loadClass("me.tbsten.compose.preview.lab.hints.PreviewHint_${expectedHash}Kt")
+                val hintMethod = hintFacade.getMethod("previewHint_$expectedHash")
+
+                // hint() を invoke すると CollectedPreview インスタンスが返る
+                val collected = hintMethod.invoke(null)
+                checkNotNull(collected) { "hint 関数が null を返した" }
+
+                val collectedClass = collected.javaClass
+                val id = collectedClass.getMethod("getId").invoke(collected) as String
+                val displayName = collectedClass.getMethod("getDisplayName").invoke(collected) as String
+
+                id shouldBe "test.source.MyButton"
+                displayName shouldBe "test.source.MyButton"
+            }
+
+        test("@Preview が複数あれば hint が複数 emit される")
+            .config(enabled = supports) {
+                val result = base.compile(
+                    SourceFile.kotlin(
+                        "Previews.kt",
+                        """
+                        package test.source
+
+                        @org.jetbrains.compose.ui.tooling.preview.Preview
+                        fun First() {}
+
+                        @org.jetbrains.compose.ui.tooling.preview.Preview
+                        fun Second() {}
+                        """,
+                    ),
+                )
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                val firstHash = computeSourceFqnHash("test.source.First")
+                val secondHash = computeSourceFqnHash("test.source.Second")
+                firstHash shouldBe firstHash // sanity (deterministic)
+
+                val classFiles = result.outputDirectory.walkTopDown()
+                    .filter { it.isFile && it.name.endsWith(".class") }
+                    .map { it.relativeTo(result.outputDirectory).path }
+                    .toList()
+
+                classFiles shouldExist {
+                    it == "me/tbsten/compose/preview/lab/hints/PreviewHint_${firstHash}Kt.class"
+                }
+                classFiles shouldExist {
+                    it == "me/tbsten/compose/preview/lab/hints/PreviewHint_${secondHash}Kt.class"
+                }
+            }
+
+        test("同じ source FQN の hash は projectRootPath に依存せず再現可能")
+            .config(enabled = supports) {
+                // hash 関数自体の reproducibility を verify (compile 越しではなく直接)
+                val a = computeSourceFqnHash("uiLib.button.MyButton")
+                val b = computeSourceFqnHash("uiLib.button.MyButton")
+                a shouldBe b
+            }
+    })


### PR DESCRIPTION
## Summary

- redesign-hint-mechanism の T02: `@Preview` 1 個に対し 1 個の hint 関数 `previewHint_<sha256(sourceFqn)>(): CollectedPreview` を `me.tbsten.compose.preview.lab.hints` package に emit する Metro 風 per-declaration hint 機構を追加
- 旧モジュール集約 hint (`previewLabExport(value: Marker)` + `previewLabAutoProvider_<hash>(): List<CollectedPreview>`) と併存。 leaf 判定 / KMP source-set fragment 名 hardcoding に依存しない設計
- 戻り値型を `CollectedPreview` 直接にすることで FIR 側 annotation 構築の煩雑さを回避し、 既存 `CollectedPreviewIrBuilder.buildCollectedPreviewCall` を再利用

実装:
- `PreviewHintFirGeneratorV2` (FIR side): `@Preview` predicate walk + hint declaration emit
- `PreviewHintIrBodyFillerV2` (IR side): hint stub の body に `CollectedPreview(...)` constructor 呼び出しを `irReturn` する形で埋める
- `SourceFqnHash`: `sha256(sourceFqn)` base-36 8 文字 hash util (reproducible build 設計)

設計判断:
- 当初は `previewHint_<hash>(): PreviewContent` で metadata は `@PreviewHint` annotation 経由で carry する案だったが、 FIR で `FirAnnotationCall` を resolved phase で組むのが煩雑だったため、 `CollectedPreview` を直接 return する形に変更 (元 PR #169 はその過程で close)
- `@ComposePreviewLabOption(ignore = true)` でも hint emit する (FIR phase で annotation argument 読み取りが安定しないため)。 cross-module で ignore preview を露出させない follow-up が必要 (TODO)

Consumer 側 discovery は次の T03、 全 KMP target での acceptance は T04 で対応。

Refs: `.local/ticket/redesign-hint-mechanism/02-v2-implementation.md`

## Test plan

- [x] `./gradlew :compiler-plugin:test` 全 green (新規 4 件 + 既存 V1 関連 全件)
- [x] `./gradlew ktlintCheck` pass
- [x] `./gradlew :compiler-plugin:apiCheck :core:apiCheck` pass
- [x] kctfork: hint class file が `me/tbsten/compose/preview/lab/hints/PreviewHint_<hash>Kt.class` で emit
- [x] kctfork: hint invoke で `CollectedPreview` インスタンス取得、 id / displayName が source FQN と一致
- [x] kctfork: 同 module に複数 `@Preview` がある場合、 別 hash で別 hint 関数が emit
- [x] kctfork: hash 関数自体が projectRootPath に依存せず再現可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)