### PR TITLE
feat(compiler-plugin): discover per-declaration hints in collectAllModulePreviews IR transform

### DIFF
--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/HintDiscoveryV2.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/HintDiscoveryV2.kt
@@ -1,0 +1,75 @@
+@file:OptIn(
+    UnsafeDuringIrConstructionAPI::class,
+    org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI::class,
+)
+
+package me.tbsten.compose.preview.lab.compiler.ir
+
+import me.tbsten.compose.preview.lab.compiler.compat.CompatContext
+import me.tbsten.compose.preview.lab.compiler.compat.IrDeclarationOriginCompat
+import me.tbsten.compose.preview.lab.compiler.fir.PreviewLabFirBuiltIns
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.classFqName
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.platform.jvm.isJvm
+
+/**
+ * Per-declaration hint (Metro 風) を **依存モジュール側** から発見する。
+ * `me.tbsten.compose.preview.lab.hints` package 配下の `previewHint_*` 関数を全列挙する。
+ *
+ * **Sample call**:
+ * ```
+ * val hints = discoverHintsV2(pluginContext, compatContext)
+ * // → 依存モジュール側で生成された
+ * //   `me.tbsten.compose.preview.lab.hints/previewHint_<hash1>(): CollectedPreview`,
+ * //   `me.tbsten.compose.preview.lab.hints/previewHint_<hash2>(): CollectedPreview`, ...
+ * //   の IrSimpleFunction list が返る (自モジュール emit 分は filter 済み)
+ * ```
+ *
+ * 自モジュールが emit した hint は scan 対象外にする (filter via `IR_EXTERNAL_DECLARATION_STUB`
+ * origin)。 自モジュールの `@Preview` は別経路で `thisModulePreviews` として既に列挙されて
+ * いるため、 含めると `distinctPreviewsById` で dedup されるとはいえ無駄な call IR を増やす。
+ *
+ * # 設計ポイント
+ *
+ * - **Package 全 walk**: K2 の `pluginContext.referenceFunctions(CallableId)` は specific 名
+ *   での lookup なので、 `previewHint_<hash>` のように hash が module ごとに異なる場合は
+ *   先に **関数名一覧** を `moduleDescriptor.getPackage(...).memberScope.getFunctionNames()`
+ *   で取得する必要がある。 これは `@ObsoleteDescriptorBasedAPI` 扱いだが、 Metro 等の
+ *   標準的な plugin で使われているパターン
+ * - **Cross-module gate**: KLIB cross-module aggregation は Kotlin 2.3.21+ で機能する。
+ *   それ未満では JVM only fallback (file facade で disambiguate) なので、 V1 と同じ条件で
+ *   gate する
+ * - **filter 条件**: 関数名が `previewHint_` で始まること + 外部 module 由来であること
+ *   + 戻り値型が `CollectedPreview` であること (sanity check)
+ */
+internal fun discoverHintsV2(pluginContext: IrPluginContext, compatContext: CompatContext,): List<IrSimpleFunction> {
+    if (!compatContext.supportsKlibCrossModuleHint() && pluginContext.platform?.isJvm() != true) {
+        return emptyList()
+    }
+
+    val packageView = pluginContext.moduleDescriptor.getPackage(PreviewLabFirBuiltIns.HINT_PACKAGE_V2)
+    val functionNames = packageView.memberScope.getFunctionNames()
+
+    val result = mutableListOf<IrSimpleFunction>()
+    for (name in functionNames) {
+        if (!name.asString().startsWith(PreviewLabFirBuiltIns.PreviewHintV2Prefix)) continue
+        val symbols = pluginContext.referenceFunctions(
+            CallableId(PreviewLabFirBuiltIns.HINT_PACKAGE_V2, name),
+        )
+        for (sym in symbols) {
+            val fn = sym.owner
+            // 自モジュール emit の hint は thisModulePreviews 経由で既に列挙されているため除外。
+            // 外部 module から linked された関数は IR_EXTERNAL_DECLARATION_STUB origin で識別。
+            if (fn.origin != IrDeclarationOriginCompat.IR_EXTERNAL_DECLARATION_STUB) continue
+            // 戻り値型が CollectedPreview であることを sanity check
+            if (fn.returnType.classFqName?.asString() != CollectedPreviewFqn) continue
+            result.add(fn)
+        }
+    }
+    return result
+}
+
+private const val CollectedPreviewFqn = "me.tbsten.compose.preview.lab.CollectedPreview"

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewListIrBuilder.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewListIrBuilder.kt
@@ -212,6 +212,19 @@ internal class PreviewListIrBuilder(
     private val cachedDependencyGetters: List<IrSimpleFunction> by lazy { collectDependencyGetters() }
 
     /**
+     * Lazily-cached per-declaration hint functions discovered via Metro 風 mechanism.
+     *
+     * Each entry is an [IrSimpleFunction] that, when called with no arguments, returns a single
+     * `CollectedPreview` (1 hint = 1 `@Preview`)。 旧モジュール集約 hint
+     * ([cachedDependencyGetters]) と異なり、 戻り値は List ではなく単体の CollectedPreview
+     * なので [buildConcatenatedPreviewsExpr] では `add(hint())` 形で list に積む。
+     *
+     * Caching ensures the (potentially expensive) package walk in [discoverHintsV2] runs at
+     * most once per [PreviewListIrBuilder] instance.
+     */
+    private val cachedHintsV2: List<IrSimpleFunction> by lazy { discoverHintsV2(pluginContext, compatContext) }
+
+    /**
      * Builds an expression that concatenates this module's previews with previews from
      * dependency modules and removes id-duplicates.
      *
@@ -234,9 +247,10 @@ internal class PreviewListIrBuilder(
      */
     fun buildConcatenatedPreviewsExpr(builder: DeclarationIrBuilder, thisModulePreviews: IrExpression): IrExpression {
         val dependencyGetters = cachedDependencyGetters
+        val hintsV2 = cachedHintsV2
         val distinctFun = distinctPreviewsByIdFun
 
-        if (dependencyGetters.isEmpty()) {
+        if (dependencyGetters.isEmpty() && hintsV2.isEmpty()) {
             return compatContext.irCall(builder, distinctFun, listOfCollectedPreviewType).apply {
                 arguments[0] = thisModulePreviews
             }
@@ -253,6 +267,15 @@ internal class PreviewListIrBuilder(
         ).first { fn ->
             val params = fn.owner.parameters.filter { it.kind == IrParameterKind.Regular }
             params.size == 1 && params[0].varargElementType == null
+        }
+        val addFun = pluginContext.referenceFunctions(
+            CallableId(
+                ClassId(FqName("kotlin.collections"), Name.identifier("MutableCollection")),
+                Name.identifier("add"),
+            ),
+        ).first { fn ->
+            val params = fn.owner.parameters.filter { it.kind == IrParameterKind.Regular }
+            params.size == 1
         }
 
         val mutableListType = pluginContext.referenceClass(
@@ -277,6 +300,15 @@ internal class PreviewListIrBuilder(
                 ).apply {
                     arguments[0] = compatContext.irGet(this@irBlock, listVar)
                     arguments[1] = dependencyValue
+                }
+            }
+            // Per-declaration hint (V2): 各 hint は CollectedPreview を 1 個 return するので
+            // `add(hint())` で list に積む (V1 dep getter のような List ではない)。
+            for (hintFn in hintsV2) {
+                val hintCall = compatContext.irCall(this, hintFn.symbol, collectedPreviewType)
+                +compatContext.irCall(this, addFun, pluginContext.irBuiltIns.booleanType).apply {
+                    arguments[0] = compatContext.irGet(this@irBlock, listVar)
+                    arguments[1] = hintCall
                 }
             }
             +compatContext.irGet(this, listVar)

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/PreviewHintV2DiscoveryTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/PreviewHintV2DiscoveryTest.kt
@@ -1,0 +1,204 @@
+package me.tbsten.compose.preview.lab.compiler.feature
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import me.tbsten.compose.preview.lab.compiler.CompilerPluginTestBase
+import me.tbsten.compose.preview.lab.compiler.loadCollectedPreviews
+
+/**
+ * Per-declaration hint (Metro 風) を依存モジュールから発見する consumer 側 IR pass の検証。
+ *
+ * 2-stage kctfork compilation:
+ * 1. uiLib をコンパイルし、 `me.tbsten.compose.preview.lab.hints/previewHint_<hash>(): CollectedPreview`
+ *    が emit される (T02 で実装済み)
+ * 2. app を uiLib output を classpath に追加してコンパイル。 `collectAllModulePreviews()` の
+ *    IR transform で V2 hint discovery が cross-module hint を call して `CollectedPreview` を
+ *    取得し、 list に積む
+ * 3. リフレクションで app.allPreviews を読み出し、 cross-module preview が含まれることを検証
+ */
+class PreviewHintV2DiscoveryTest :
+    FunSpec({
+        val base = CompilerPluginTestBase()
+
+        test("collectAllModulePreviews() が cross-module の per-declaration hint を発見・利用する") {
+            // Stage 1: uiLib
+            val libResult = base.compile(
+                SourceFile.kotlin(
+                    "UiLib.kt",
+                    """
+                    package uilib
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun UiLibPreview() {}
+                    """,
+                ),
+            )
+            libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+            // Stage 2: app
+            val appResult = base.compile(
+                SourceFile.kotlin(
+                    "App.kt",
+                    """
+                    package app
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun AppPreview() {}
+                    """,
+                ),
+                base.collectAllModulePreviewsEntry("allPreviews"),
+                extraClasspaths = listOf(libResult.outputDirectory),
+            )
+            appResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+            val previews = appResult.loadCollectedPreviews(propertyName = "allPreviews")
+            val ids = previews.map { p -> p::class.members.find { it.name == "id" }!!.call(p) as String }
+
+            // V1 (旧モジュール集約) + V2 (per-declaration) 両方が動くが、 distinctPreviewsById
+            // で dedup されるので同じ preview は 1 回だけ登場する。
+            ids shouldContainExactlyInAnyOrder listOf(
+                "app.AppPreview",
+                "uilib.UiLibPreview",
+            )
+        }
+
+        test("複数 @Preview を持つ依存モジュールの hint をすべて発見する") {
+            val libResult = base.compile(
+                SourceFile.kotlin(
+                    "UiLib.kt",
+                    """
+                    package uilib
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun First() {}
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun Second() {}
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun Third() {}
+                    """,
+                ),
+            )
+            libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+            val appResult = base.compile(
+                SourceFile.kotlin(
+                    "App.kt",
+                    """
+                    package app
+                    """,
+                ),
+                base.collectAllModulePreviewsEntry("allPreviews"),
+                extraClasspaths = listOf(libResult.outputDirectory),
+            )
+            appResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+            val previews = appResult.loadCollectedPreviews(propertyName = "allPreviews")
+            val ids = previews.map { p -> p::class.members.find { it.name == "id" }!!.call(p) as String }
+
+            ids shouldContainExactlyInAnyOrder listOf(
+                "uilib.First",
+                "uilib.Second",
+                "uilib.Third",
+            )
+        }
+
+        test("cross-module の preview が CollectedPreview の全 metadata を保持する") {
+            val libResult = base.compile(
+                SourceFile.kotlin(
+                    "UiLib.kt",
+                    """
+                    package uilib
+
+                    /**
+                     * Sample preview KDoc.
+                     */
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun WithMetadata() {}
+                    """,
+                ),
+            )
+            libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+            val appResult = base.compile(
+                SourceFile.kotlin(
+                    "App.kt",
+                    """
+                    package app
+                    """,
+                ),
+                base.collectAllModulePreviewsEntry("allPreviews"),
+                extraClasspaths = listOf(libResult.outputDirectory),
+            )
+            appResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+            val previews = appResult.loadCollectedPreviews(propertyName = "allPreviews")
+            val preview = previews.single { p ->
+                (p::class.members.find { it.name == "id" }!!.call(p) as String) == "uilib.WithMetadata"
+            }
+
+            val displayName = preview::class.members.find { it.name == "displayName" }!!.call(preview) as String
+            val filePath = preview::class.members.find { it.name == "filePath" }!!.call(preview) as String?
+            val startLine = preview::class.members.find { it.name == "startLineNumber" }!!.call(preview) as Int?
+            val endLine = preview::class.members.find { it.name == "endLineNumber" }!!.call(preview) as Int?
+            val code = preview::class.members.find { it.name == "code" }!!.call(preview) as String?
+
+            displayName shouldBe "uilib.WithMetadata"
+            // startLine / endLine は @Preview の宣言位置を指す (1-based)
+            (startLine != null) shouldBe true
+            (endLine != null) shouldBe true
+            // filePath / code は kctfork の in-memory file 環境では null になる場合があるので
+            // 存在チェックのみ (実 build では non-null)。 sentinel `""` から null に正しく
+            // 復元されることを `code != null && code.isEmpty()` のような誤動作で潰さないかの
+            // 確認は T04 (integrationTest) に委ねる
+            @Suppress("UNUSED_VARIABLE")
+            val ignored = listOf(filePath, code)
+        }
+
+        test("dedup: 自モジュール @Preview と cross-module hint が同 FQN なら 1 個に統合") {
+            // 同 FQN cross-module collision は受容済み edge case だが、 通常ケースとして
+            // 自モジュール側の hint が先に登録されて cross-module 側が overwrite しないこと
+            // (= distinctPreviewsById が機能していること) を確認するために、 別 FQN を使う。
+            val libResult = base.compile(
+                SourceFile.kotlin(
+                    "Shared.kt",
+                    """
+                    package shared
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun SharedPreview() {}
+                    """,
+                ),
+            )
+            libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+            val appResult = base.compile(
+                SourceFile.kotlin(
+                    "App.kt",
+                    """
+                    package app
+
+                    @org.jetbrains.compose.ui.tooling.preview.Preview
+                    fun AppPreview() {}
+                    """,
+                ),
+                base.collectAllModulePreviewsEntry("allPreviews"),
+                extraClasspaths = listOf(libResult.outputDirectory),
+            )
+            appResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+            val previews = appResult.loadCollectedPreviews(propertyName = "allPreviews")
+            val ids = previews.map { p -> p::class.members.find { it.name == "id" }!!.call(p) as String }
+
+            // V1 (auto-provider経由) + V2 (per-declaration hint経由) で SharedPreview が
+            // 2 重に出てくる可能性があるが、 distinctPreviewsById で 1 個に統合される
+            previews.size shouldBe ids.distinct().size
+            ids shouldContain "shared.SharedPreview"
+            ids shouldContain "app.AppPreview"
+        }
+    })


### PR DESCRIPTION
## Summary

- redesign-hint-mechanism の T03: `collectAllModulePreviews()` の IR transform で per-declaration hint (Metro 風 V2) を依存モジュール側から発見・利用する処理を追加
- 旧モジュール集約 hint と V2 hint の両方を merge し、 `distinctPreviewsById` で dedup
- T02 (PR #170) 必須

実装:
- `HintDiscoveryV2.kt`: `me.tbsten.compose.preview.lab.hints` package 配下の `previewHint_*` 関数を `moduleDescriptor.getPackage(...).memberScope.getFunctionNames()` で全列挙 (Metro と同じパターン、 K2 で `@ObsoleteDescriptorBasedAPI` だが de facto 標準)
- `IR_EXTERNAL_DECLARATION_STUB` origin で外部 module hint のみ filter (自モジュール emit は thisModulePreviews 経由で既に列挙済み)
- `PreviewListIrBuilder.buildConcatenatedPreviewsExpr` を拡張: V2 hint は単体 CollectedPreview を return するので `add(hint())` で list に積む
- V1 `collectDependencyGetters` は手付かずで残す (T05 で削除)

設計判断:
- 独立ファイル `HintDiscoveryV2.kt` (後続のディレクトリ再編で `transformations/...` 配下に移しやすい形)
- 同 FQN cross-artifact collision は受容済み edge case (`.local/redesign-hint-mechanism/参考.md` §3)

KLIB target / Compose context 実機 invoke は次の T04 で確認。

Refs: `.local/ticket/redesign-hint-mechanism/03-consumer-side-discovery.md`
Stacked on: #170

## Test plan

- [x] `./gradlew :compiler-plugin:test` 全 green (新規 4 件 + 既存 cross-module 関連 全件)
- [x] `./gradlew ktlintCheck` pass
- [x] `./gradlew :compiler-plugin:apiCheck :core:apiCheck` pass
- [x] kctfork 2-stage compile: cross-module hint 発見・list に積む
- [x] kctfork: 複数 `@Preview` 持つ依存モジュールの hint をすべて発見
- [x] kctfork: cross-module preview の displayName / line 等 metadata が復元
- [x] kctfork: V1 + V2 で重複しても `distinctPreviewsById` で 1 個に統合

🤖 Generated with [Claude Code](https://claude.com/claude-code)