### PR TITLE
test(integrationTest): V2 acceptance gate — verify V1+V2 coexistence and dedup across KMP targets

### DIFF
--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/PreviewHintV2DiscoveryTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/PreviewHintV2DiscoveryTest.kt
@@ -160,10 +160,12 @@ class PreviewHintV2DiscoveryTest :
             val ignored = listOf(filePath, code)
         }
 
-        test("dedup: 自モジュール @Preview と cross-module hint が同 FQN なら 1 個に統合") {
-            // 同 FQN cross-module collision は受容済み edge case だが、 通常ケースとして
-            // 自モジュール側の hint が先に登録されて cross-module 側が overwrite しないこと
-            // (= distinctPreviewsById が機能していること) を確認するために、 別 FQN を使う。
+        test("dedup: 同一 preview が V1 (auto-provider) と V2 (per-declaration hint) の両 path から到達しても 1 個に統合される") {
+            // T04 時点では V1 (auto-provider 経由の旧モジュール集約) と V2 (per-declaration hint
+            // 経由の新方式) が共存しているため、 dependency module の `@Preview` は app 側で
+            //   - V1 path: app の auto-provider 経由で lib の preview list を集約
+            //   - V2 path: discoverHintsV2 で lib の `previewHint_<hash>()` を発見 → call
+            // の 2 経路で到達する。 distinctPreviewsById により id 重複が排除されることを検証する。
             val libResult = base.compile(
                 SourceFile.kotlin(
                     "Shared.kt",
@@ -195,10 +197,12 @@ class PreviewHintV2DiscoveryTest :
             val previews = appResult.loadCollectedPreviews(propertyName = "allPreviews")
             val ids = previews.map { p -> p::class.members.find { it.name == "id" }!!.call(p) as String }
 
-            // V1 (auto-provider経由) + V2 (per-declaration hint経由) で SharedPreview が
-            // 2 重に出てくる可能性があるが、 distinctPreviewsById で 1 個に統合される
+            // shared.SharedPreview が 2 重に出てくる可能性があるが、 distinctPreviewsById で
+            // 1 個に統合される (size == distinct size で重複ゼロを assert)
             previews.size shouldBe ids.distinct().size
             ids shouldContain "shared.SharedPreview"
             ids shouldContain "app.AppPreview"
+            // shared.SharedPreview が dedup 後も 1 個だけ残っていることを明示的に確認
+            ids.count { it == "shared.SharedPreview" } shouldBe 1
         }
     })

--- a/integrationTest/app/src/commonTest/kotlin/CrossModuleCollectPreviewsTest.kt
+++ b/integrationTest/app/src/commonTest/kotlin/CrossModuleCollectPreviewsTest.kt
@@ -29,4 +29,19 @@ class CrossModuleCollectPreviewsTest {
                 "is broken on this target.",
         )
     }
+
+    /**
+     * 旧モジュール集約 hint と per-declaration hint (Metro 風 / T03) の両方が動いている期間中は
+     * 同一 `@Preview` から `CollectedPreview` が 2 個 emit される (V1 経由 + V2 経由)。
+     * `collectAllModulePreviews()` の IR transform は最終的に `distinctPreviewsById` で
+     * dedup するので、 結果 list の `id` がユニークであることを assert する。
+     */
+    @Test
+    fun collectAllModulePreviewsDeduplicatesById() {
+        val ids = appPreviews.map { it.id }
+        assertTrue(
+            ids.size == ids.distinct().size,
+            "appPreviews has id duplicates: ${ids.groupingBy { it }.eachCount().filter { it.value > 1 }}",
+        )
+    }
 }


### PR DESCRIPTION
## Summary

- redesign-hint-mechanism の T04: V1 削除前の最終 acceptance gate
- 旧モジュール集約 hint と per-declaration hint (Metro 風 / T03) の併存状態が全 KMP target で動作することを確認
- integrationTest に dedup assertion (`id` ユニーク) を追加 (V1 + V2 両方 emit でも `distinctPreviewsById` で正しく dedup される)
- T03 (PR #171) 必須

実機検証結果:
- ✅ `(cd integrationTest && ./gradlew jvmTest jsBrowserTest wasmJsBrowserTest testDebugUnitTest)` 全 green
- ⚠️ `iosSimulatorArm64Test` は環境制約 (xcrun / Xcode 設定) でローカル skip。 CI で確認
- ✅ `./gradlew jvmTest jsBrowserTest wasmJsBrowserTest testDebugUnitTest` (main repo) 全 green
- ✅ `./gradlew :core:compileKotlin{Jvm,Js,WasmJs} :core:compileDebugKotlinAndroid` (および preview-lab 側) 全 green
- ✅ apiCheck / ktlintCheck pass
- ✅ hint duplication check: 各 module 内で hint class file 重複なし
- ✅ IC smoke (2 回連続実行): green

iOS のローカル実機検証は CI 任せで、 V1 削除 (T05) に進むためのコード変更は dedup assertion 追加のみ。

Refs: `.local/ticket/redesign-hint-mechanism/04-v2-acceptance-gate.md`
Stacked on: #171

## Test plan

- [x] `./gradlew jvmTest jsBrowserTest wasmJsBrowserTest testDebugUnitTest` 全 green
- [x] `(cd integrationTest && ./gradlew jvmTest jsBrowserTest wasmJsBrowserTest testDebugUnitTest)` 全 green
- [x] hint duplication check + IC smoke
- [ ] CI で iOS target 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)