### PR TITLE
build(integrationTest): enable apiDump / apiCheck

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Validate Binary Compatibility
         shell: bash
         run: ./gradlew apiCheck
+      - name: Validate Binary Compatibility (integrationTest)
+        shell: bash
+        run: cd ./integrationTest && ./gradlew apiCheck
   test:
     strategy:
       fail-fast: false

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,8 +43,9 @@ jobs:
         shell: bash
         run: ./gradlew apiCheck
       - name: Validate Binary Compatibility (integrationTest)
+        working-directory: integrationTest
         shell: bash
-        run: cd ./integrationTest && ./gradlew apiCheck
+        run: ./gradlew apiCheck
   test:
     strategy:
       fail-fast: false

--- a/integrationTest/app/api/android/app.api
+++ b/integrationTest/app/api/android/app.api
@@ -1,0 +1,94 @@
+public final class app/ComposableSingletons$PreviewsKt {
+	public static final field INSTANCE Lapp/ComposableSingletons$PreviewsKt;
+	public fun <init> ()V
+	public final fun getLambda$-1571401955$app_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1997758206$app_release ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class app/FeaturedFileList : java/util/Map, kotlin/jvm/internal/markers/KMappedMarker {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/FeaturedFileList;
+	public fun clear ()V
+	public synthetic fun compute (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun compute (Ljava/lang/String;Ljava/util/function/BiFunction;)Ljava/util/List;
+	public synthetic fun computeIfAbsent (Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;
+	public fun computeIfAbsent (Ljava/lang/String;Ljava/util/function/Function;)Ljava/util/List;
+	public synthetic fun computeIfPresent (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun computeIfPresent (Ljava/lang/String;Ljava/util/function/BiFunction;)Ljava/util/List;
+	public final fun containsKey (Ljava/lang/Object;)Z
+	public fun containsKey (Ljava/lang/String;)Z
+	public final fun containsValue (Ljava/lang/Object;)Z
+	public fun containsValue (Ljava/util/List;)Z
+	public final fun entrySet ()Ljava/util/Set;
+	public fun equals (Ljava/lang/Object;)Z
+	public final synthetic fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun get (Ljava/lang/Object;)Ljava/util/List;
+	public fun get (Ljava/lang/String;)Ljava/util/List;
+	public fun getEntries ()Ljava/util/Set;
+	public fun getKeys ()Ljava/util/Set;
+	public final fun getPr_123 ()Ljava/util/List;
+	public final fun getSample_design_system ()Ljava/util/List;
+	public fun getSize ()I
+	public fun getValues ()Ljava/util/Collection;
+	public fun hashCode ()I
+	public fun isEmpty ()Z
+	public final fun keySet ()Ljava/util/Set;
+	public synthetic fun merge (Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun merge (Ljava/lang/String;Ljava/util/List;Ljava/util/function/BiFunction;)Ljava/util/List;
+	public synthetic fun put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun put (Ljava/lang/String;Ljava/util/List;)Ljava/util/List;
+	public fun putAll (Ljava/util/Map;)V
+	public synthetic fun putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun putIfAbsent (Ljava/lang/String;Ljava/util/List;)Ljava/util/List;
+	public synthetic fun remove (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;)Ljava/util/List;
+	public fun remove (Ljava/lang/Object;Ljava/lang/Object;)Z
+	public synthetic fun replace (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun replace (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Z
+	public fun replace (Ljava/lang/String;Ljava/util/List;)Ljava/util/List;
+	public fun replace (Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Z
+	public fun replaceAll (Ljava/util/function/BiFunction;)V
+	public final fun size ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun values ()Ljava/util/Collection;
+}
+
+public final class app/PreviewsKt {
+	public static final fun getAppModulePreviews ()Ljava/util/List;
+	public static final fun getAppPreviews ()Ljava/util/List;
+}
+
+public final class me/tbsten/compose/preview/lab/sample/AppActivity : androidx/activity/ComponentActivity {
+	public static final field $stable I
+	public fun <init> ()V
+}
+
+public final class me/tbsten/compose/preview/lab/sample/ComposableSingletons$App_androidKt {
+	public static final field INSTANCE Lme/tbsten/compose/preview/lab/sample/ComposableSingletons$App_androidKt;
+	public fun <init> ()V
+	public final fun getLambda$309299553$app_release ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class me/tbsten/compose/preview/lab/sample/ComposableSingletons$ComposeMultiplatformWizardDefaultUIKt {
+	public static final field INSTANCE Lme/tbsten/compose/preview/lab/sample/ComposableSingletons$ComposeMultiplatformWizardDefaultUIKt;
+	public fun <init> ()V
+	public final fun getLambda$-225562192$app_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-77196509$app_release ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class me/tbsten/compose/preview/lab/sample/ComposableSingletons$LabPreviewsSampleKt {
+	public static final field INSTANCE Lme/tbsten/compose/preview/lab/sample/ComposableSingletons$LabPreviewsSampleKt;
+	public fun <init> ()V
+	public final fun getLambda$-1156868874$app_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-269646028$app_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-713257451$app_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$458589272$app_release ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class me/tbsten/compose/preview/lab/sample/LabPreviewsSampleKt {
+	public static final fun Test (Landroidx/compose/runtime/Composer;I)V
+	public static final fun Test1 (Landroidx/compose/runtime/Composer;I)V
+	public static final fun Test2 (Landroidx/compose/runtime/Composer;I)V
+	public static final fun Test3 (Landroidx/compose/runtime/Composer;I)V
+}
+

--- a/integrationTest/app/api/app.klib.api
+++ b/integrationTest/app/api/app.klib.api
@@ -1,0 +1,65 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, js, wasmJs]
+// Alias: ios => [iosArm64, iosSimulatorArm64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <Compose-Preview-Lab-Integration-Test:app>
+final object app/FeaturedFileList : kotlin.collections/Map<kotlin/String, kotlin.collections/List<kotlin/String>> { // app/FeaturedFileList|null[0]
+    final val entries // app/FeaturedFileList.entries|{}entries[0]
+        final fun <get-entries>(): kotlin.collections/Set<kotlin.collections/Map.Entry<kotlin/String, kotlin.collections/List<kotlin/String>>> // app/FeaturedFileList.entries.<get-entries>|<get-entries>(){}[0]
+    final val keys // app/FeaturedFileList.keys|{}keys[0]
+        final fun <get-keys>(): kotlin.collections/Set<kotlin/String> // app/FeaturedFileList.keys.<get-keys>|<get-keys>(){}[0]
+    final val pr_123 // app/FeaturedFileList.pr_123|{}pr_123[0]
+        final fun <get-pr_123>(): kotlin.collections/List<kotlin/String> // app/FeaturedFileList.pr_123.<get-pr_123>|<get-pr_123>(){}[0]
+    final val sample_design_system // app/FeaturedFileList.sample_design_system|{}sample_design_system[0]
+        final fun <get-sample_design_system>(): kotlin.collections/List<kotlin/String> // app/FeaturedFileList.sample_design_system.<get-sample_design_system>|<get-sample_design_system>(){}[0]
+    final val size // app/FeaturedFileList.size|{}size[0]
+        final fun <get-size>(): kotlin/Int // app/FeaturedFileList.size.<get-size>|<get-size>(){}[0]
+    final val values // app/FeaturedFileList.values|{}values[0]
+        final fun <get-values>(): kotlin.collections/Collection<kotlin.collections/List<kotlin/String>> // app/FeaturedFileList.values.<get-values>|<get-values>(){}[0]
+
+    final fun containsKey(kotlin/String): kotlin/Boolean // app/FeaturedFileList.containsKey|containsKey(kotlin.String){}[0]
+    final fun containsValue(kotlin.collections/List<kotlin/String>): kotlin/Boolean // app/FeaturedFileList.containsValue|containsValue(kotlin.collections.List<kotlin.String>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // app/FeaturedFileList.equals|equals(kotlin.Any?){}[0]
+    final fun get(kotlin/String): kotlin.collections/List<kotlin/String>? // app/FeaturedFileList.get|get(kotlin.String){}[0]
+    final fun hashCode(): kotlin/Int // app/FeaturedFileList.hashCode|hashCode(){}[0]
+    final fun isEmpty(): kotlin/Boolean // app/FeaturedFileList.isEmpty|isEmpty(){}[0]
+    final fun toString(): kotlin/String // app/FeaturedFileList.toString|toString(){}[0]
+
+    // Targets: [js]
+    final fun asJsReadonlyMapView(): kotlin.js.collections/JsReadonlyMap<kotlin/String, kotlin.collections/List<kotlin/String>> // app/FeaturedFileList.asJsReadonlyMapView|asJsReadonlyMapView(){}[0]
+}
+
+final val app/appModulePreviews // app/appModulePreviews|{}appModulePreviews[0]
+    final fun <get-appModulePreviews>(): kotlin.collections/List<me.tbsten.compose.preview.lab/CollectedPreview> // app/appModulePreviews.<get-appModulePreviews>|<get-appModulePreviews>(){}[0]
+final val app/appPreviews // app/appPreviews|{}appPreviews[0]
+    final fun <get-appPreviews>(): kotlin.collections/List<me.tbsten.compose.preview.lab/CollectedPreview> // app/appPreviews.<get-appPreviews>|<get-appPreviews>(){}[0]
+final val app/app_FeaturedFileList$stableprop // app/app_FeaturedFileList$stableprop|#static{}app_FeaturedFileList$stableprop[0]
+final val compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_array$stableprop // compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_array$stableprop|#static{}compose_preview_lab_integration_test_app_generated_resources_Res_array$stableprop[0]
+final val compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_drawable$stableprop // compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_drawable$stableprop|#static{}compose_preview_lab_integration_test_app_generated_resources_Res_drawable$stableprop[0]
+final val compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_font$stableprop // compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_font$stableprop|#static{}compose_preview_lab_integration_test_app_generated_resources_Res_font$stableprop[0]
+final val compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_plurals$stableprop // compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_plurals$stableprop|#static{}compose_preview_lab_integration_test_app_generated_resources_Res_plurals$stableprop[0]
+final val compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_string$stableprop // compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_string$stableprop|#static{}compose_preview_lab_integration_test_app_generated_resources_Res_string$stableprop[0]
+
+final fun app/app_FeaturedFileList$stableprop_getter(): kotlin/Int // app/app_FeaturedFileList$stableprop_getter|app_FeaturedFileList$stableprop_getter(){}[0]
+final fun compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_array$stableprop_getter(): kotlin/Int // compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_array$stableprop_getter|compose_preview_lab_integration_test_app_generated_resources_Res_array$stableprop_getter(){}[0]
+final fun compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_drawable$stableprop_getter(): kotlin/Int // compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_drawable$stableprop_getter|compose_preview_lab_integration_test_app_generated_resources_Res_drawable$stableprop_getter(){}[0]
+final fun compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_font$stableprop_getter(): kotlin/Int // compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_font$stableprop_getter|compose_preview_lab_integration_test_app_generated_resources_Res_font$stableprop_getter(){}[0]
+final fun compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_plurals$stableprop_getter(): kotlin/Int // compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_plurals$stableprop_getter|compose_preview_lab_integration_test_app_generated_resources_Res_plurals$stableprop_getter(){}[0]
+final fun compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_string$stableprop_getter(): kotlin/Int // compose_preview_lab_integration_test.app.generated.resources/compose_preview_lab_integration_test_app_generated_resources_Res_string$stableprop_getter|compose_preview_lab_integration_test_app_generated_resources_Res_string$stableprop_getter(){}[0]
+
+// Targets: [ios]
+final fun /MainViewController(): platform.UIKit/UIViewController // /MainViewController|MainViewController(){}[0]
+
+// Targets: [js, wasmJs]
+final fun /main() // /main|main(){}[0]
+
+// Targets: [js]
+final val /appPreviewList // /appPreviewList|{}appPreviewList[0]
+    final fun <get-appPreviewList>(): kotlin/Array<me.tbsten.compose.preview.lab/CollectedPreview> // /appPreviewList.<get-appPreviewList>|<get-appPreviewList>(){}[0]
+
+// Targets: [js]
+final fun /renderPreviewById(org.w3c.dom/Element, kotlin/String): kotlin/Function0<kotlin/Unit> // /renderPreviewById|renderPreviewById(org.w3c.dom.Element;kotlin.String){}[0]

--- a/integrationTest/app/api/jvm/app.api
+++ b/integrationTest/app/api/jvm/app.api
@@ -1,0 +1,78 @@
+public final class ComposableSingletons$MainKt {
+	public static final field INSTANCE LComposableSingletons$MainKt;
+	public fun <init> ()V
+	public final fun getLambda$-1618970650$app ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class MainKt {
+	public static final fun main ()V
+	public static synthetic fun main ([Ljava/lang/String;)V
+}
+
+public final class app/ComposableSingletons$PreviewsKt {
+	public static final field INSTANCE Lapp/ComposableSingletons$PreviewsKt;
+	public fun <init> ()V
+	public final fun getLambda$-1571401955$app ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1997758206$app ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class app/FeaturedFileList : java/util/Map, kotlin/jvm/internal/markers/KMappedMarker {
+	public static final field $stable I
+	public static final field INSTANCE Lapp/FeaturedFileList;
+	public fun clear ()V
+	public synthetic fun compute (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun compute (Ljava/lang/String;Ljava/util/function/BiFunction;)Ljava/util/List;
+	public synthetic fun computeIfAbsent (Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;
+	public fun computeIfAbsent (Ljava/lang/String;Ljava/util/function/Function;)Ljava/util/List;
+	public synthetic fun computeIfPresent (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun computeIfPresent (Ljava/lang/String;Ljava/util/function/BiFunction;)Ljava/util/List;
+	public final fun containsKey (Ljava/lang/Object;)Z
+	public fun containsKey (Ljava/lang/String;)Z
+	public final fun containsValue (Ljava/lang/Object;)Z
+	public fun containsValue (Ljava/util/List;)Z
+	public final fun entrySet ()Ljava/util/Set;
+	public fun equals (Ljava/lang/Object;)Z
+	public final synthetic fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun get (Ljava/lang/Object;)Ljava/util/List;
+	public fun get (Ljava/lang/String;)Ljava/util/List;
+	public fun getEntries ()Ljava/util/Set;
+	public fun getKeys ()Ljava/util/Set;
+	public final fun getPr_123 ()Ljava/util/List;
+	public final fun getSample_design_system ()Ljava/util/List;
+	public fun getSize ()I
+	public fun getValues ()Ljava/util/Collection;
+	public fun hashCode ()I
+	public fun isEmpty ()Z
+	public final fun keySet ()Ljava/util/Set;
+	public synthetic fun merge (Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun merge (Ljava/lang/String;Ljava/util/List;Ljava/util/function/BiFunction;)Ljava/util/List;
+	public synthetic fun put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun put (Ljava/lang/String;Ljava/util/List;)Ljava/util/List;
+	public fun putAll (Ljava/util/Map;)V
+	public synthetic fun putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun putIfAbsent (Ljava/lang/String;Ljava/util/List;)Ljava/util/List;
+	public synthetic fun remove (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;)Ljava/util/List;
+	public fun remove (Ljava/lang/Object;Ljava/lang/Object;)Z
+	public synthetic fun replace (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun replace (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Z
+	public fun replace (Ljava/lang/String;Ljava/util/List;)Ljava/util/List;
+	public fun replace (Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Z
+	public fun replaceAll (Ljava/util/function/BiFunction;)V
+	public final fun size ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun values ()Ljava/util/Collection;
+}
+
+public final class app/PreviewsKt {
+	public static final fun getAppModulePreviews ()Ljava/util/List;
+	public static final fun getAppPreviews ()Ljava/util/List;
+}
+
+public final class me/tbsten/compose/preview/lab/sample/ComposableSingletons$ComposeMultiplatformWizardDefaultUIKt {
+	public static final field INSTANCE Lme/tbsten/compose/preview/lab/sample/ComposableSingletons$ComposeMultiplatformWizardDefaultUIKt;
+	public fun <init> ()V
+	public final fun getLambda$-225562192$app ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-77196509$app ()Lkotlin/jvm/functions/Function3;
+}
+

--- a/integrationTest/build.gradle.kts
+++ b/integrationTest/build.gradle.kts
@@ -1,3 +1,5 @@
+import kotlinx.validation.ExperimentalBCVApi
+
 plugins {
     alias(libs.plugins.kotlinMultiplatform).apply(false)
     alias(libs.plugins.composeCompiler).apply(false)
@@ -6,4 +8,22 @@ plugins {
     alias(libs.plugins.androidLibrary).apply(false)
     alias(libs.plugins.hotReload).apply(false)
     id("me.tbsten.compose.preview.lab").apply(false)
+    alias(libs.plugins.binaryCompatibilityValidator)
+}
+
+apiValidation {
+    @OptIn(ExperimentalBCVApi::class)
+    klib.enabled = true
+
+    nonPublicMarkers.addAll(
+        listOf(
+            "me.tbsten.compose.preview.lab.InternalComposePreviewLabApi",
+            "me.tbsten.compose.preview.lab.UiComposePreviewLabApi",
+        ),
+    )
+
+    // Compiler plugin generates classes with environment-dependent hash suffixes
+    // (e.g. PreviewLabAutoProvider_<hash>Kt). Exclude this internal package from
+    // apiCheck to avoid spurious failures across different build environments.
+    ignoredPackages.add("me.tbsten.compose.preview.lab.exports")
 }

--- a/integrationTest/uiLib/api/android/uiLib.api
+++ b/integrationTest/uiLib/api/android/uiLib.api
@@ -1,0 +1,30 @@
+public final class me/tbsten/compose/preview/lab/sample/lib/ComposableSingletons$MyButtonKt {
+	public static final field INSTANCE Lme/tbsten/compose/preview/lab/sample/lib/ComposableSingletons$MyButtonKt;
+	public fun <init> ()V
+	public final fun getLambda$-1754467782$uiLib_release ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class me/tbsten/compose/preview/lab/sample/lib/ComposableSingletons$MyTextFieldKt {
+	public static final field INSTANCE Lme/tbsten/compose/preview/lab/sample/lib/ComposableSingletons$MyTextFieldKt;
+	public fun <init> ()V
+	public final fun getLambda$1785476826$uiLib_release ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class me/tbsten/compose/preview/lab/sample/lib/ComposableSingletons$PreviewLabKt {
+	public static final field INSTANCE Lme/tbsten/compose/preview/lab/sample/lib/ComposableSingletons$PreviewLabKt;
+	public fun <init> ()V
+	public final fun getLambda$-1183720737$uiLib_release ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class me/tbsten/compose/preview/lab/sample/lib/MyButtonKt {
+	public static final fun MyButton (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class me/tbsten/compose/preview/lab/sample/lib/MyTextFieldKt {
+	public static final fun MyTextField (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class me/tbsten/compose/preview/lab/sample/lib/PreviewLabKt {
+	public static final fun CustomizedPreviewLab (Landroidx/compose/ui/Modifier;ZLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+}
+

--- a/integrationTest/uiLib/api/jvm/uiLib.api
+++ b/integrationTest/uiLib/api/jvm/uiLib.api
@@ -1,0 +1,30 @@
+public final class me/tbsten/compose/preview/lab/sample/lib/ComposableSingletons$MyButtonKt {
+	public static final field INSTANCE Lme/tbsten/compose/preview/lab/sample/lib/ComposableSingletons$MyButtonKt;
+	public fun <init> ()V
+	public final fun getLambda$-1754467782$uiLib ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class me/tbsten/compose/preview/lab/sample/lib/ComposableSingletons$MyTextFieldKt {
+	public static final field INSTANCE Lme/tbsten/compose/preview/lab/sample/lib/ComposableSingletons$MyTextFieldKt;
+	public fun <init> ()V
+	public final fun getLambda$1785476826$uiLib ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class me/tbsten/compose/preview/lab/sample/lib/ComposableSingletons$PreviewLabKt {
+	public static final field INSTANCE Lme/tbsten/compose/preview/lab/sample/lib/ComposableSingletons$PreviewLabKt;
+	public fun <init> ()V
+	public final fun getLambda$-1183720737$uiLib ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class me/tbsten/compose/preview/lab/sample/lib/MyButtonKt {
+	public static final fun MyButton (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class me/tbsten/compose/preview/lab/sample/lib/MyTextFieldKt {
+	public static final fun MyTextField (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class me/tbsten/compose/preview/lab/sample/lib/PreviewLabKt {
+	public static final fun CustomizedPreviewLab (Landroidx/compose/ui/Modifier;ZLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+}
+

--- a/integrationTest/uiLib/api/uiLib.klib.api
+++ b/integrationTest/uiLib/api/uiLib.klib.api
@@ -1,0 +1,11 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, js, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <Compose-Preview-Lab-Integration-Test:uiLib>
+final fun me.tbsten.compose.preview.lab.sample.lib/CustomizedPreviewLab(androidx.compose.ui/Modifier?, kotlin/Boolean, kotlin/Function3<me.tbsten.compose.preview.lab.previewlab/PreviewLabScope, androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // me.tbsten.compose.preview.lab.sample.lib/CustomizedPreviewLab|CustomizedPreviewLab(androidx.compose.ui.Modifier?;kotlin.Boolean;kotlin.Function3<me.tbsten.compose.preview.lab.previewlab.PreviewLabScope,androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun me.tbsten.compose.preview.lab.sample.lib/MyButton(kotlin/String, kotlin/Function0<kotlin/Unit>, androidx.compose.ui/Modifier?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // me.tbsten.compose.preview.lab.sample.lib/MyButton|MyButton(kotlin.String;kotlin.Function0<kotlin.Unit>;androidx.compose.ui.Modifier?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun me.tbsten.compose.preview.lab.sample.lib/MyTextField(kotlin/String, kotlin/Function1<kotlin/String, kotlin/Unit>, androidx.compose.ui/Modifier?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // me.tbsten.compose.preview.lab.sample.lib/MyTextField|MyTextField(kotlin.String;kotlin.Function1<kotlin.String,kotlin.Unit>;androidx.compose.ui.Modifier?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]

--- a/integrationTest/uiLibReversed/api/android/uiLibReversed.api
+++ b/integrationTest/uiLibReversed/api/android/uiLibReversed.api
@@ -1,0 +1,11 @@
+public final class me/tbsten/compose/preview/lab/sample/libreversed/ComposableSingletons$MyButtonKt {
+	public static final field INSTANCE Lme/tbsten/compose/preview/lab/sample/libreversed/ComposableSingletons$MyButtonKt;
+	public fun <init> ()V
+	public final fun getLambda$-1639038902$uiLibReversed_release ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class me/tbsten/compose/preview/lab/sample/libreversed/MyButtonKt {
+	public static final fun MyButton (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public static final fun MyButtonPreview (Landroidx/compose/runtime/Composer;I)V
+}
+

--- a/integrationTest/uiLibReversed/api/jvm/uiLibReversed.api
+++ b/integrationTest/uiLibReversed/api/jvm/uiLibReversed.api
@@ -1,0 +1,11 @@
+public final class me/tbsten/compose/preview/lab/sample/libreversed/ComposableSingletons$MyButtonKt {
+	public static final field INSTANCE Lme/tbsten/compose/preview/lab/sample/libreversed/ComposableSingletons$MyButtonKt;
+	public fun <init> ()V
+	public final fun getLambda$-1639038902$uiLibReversed ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class me/tbsten/compose/preview/lab/sample/libreversed/MyButtonKt {
+	public static final fun MyButton (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public static final fun MyButtonPreview (Landroidx/compose/runtime/Composer;I)V
+}
+


### PR DESCRIPTION
## Summary

`integrationTest/` は composite-build の独立 Gradle project (root: `Compose-Preview-Lab-Integration-Test`) で、 これまで binary-compatibility-validator が適用されておらず `(cd integrationTest && ./gradlew apiCheck)` で何も実行されなかった。 親プロジェクトと同条件で API surface を可視化・gate する。

- `integrationTest/build.gradle.kts`: `binaryCompatibilityValidator` plugin 適用 + `apiValidation` block (klib enabled / `@InternalComposePreviewLabApi` / `@UiComposePreviewLabApi` を non-public 扱い)。 `:app` も含めて 3 module 全てを gate
- 9 ファイルの初回 baseline (`{app,uiLib,uiLibReversed}/api/{*.api,*.klib.api,android/,jvm/}`) を commit
- `.github/workflows/pull-request.yml`: 既存 `validate-binary-compatibility` job に integrationTest 用の `apiCheck` step を追加

## Test plan

- [ ] `(cd integrationTest && ./gradlew tasks --all | grep -E "apiDump |apiCheck")` で `:app:apiDump`, `:uiLib:apiDump`, `:uiLibReversed:apiDump` + 各 `apiCheck` が表示
- [ ] `(cd integrationTest && ./gradlew apiCheck)` BUILD SUCCESSFUL
- [ ] CI workflow `Validate Binary Compatibility` job が新 step (integrationTest) も実行して green
- [ ] uiLib のいずれかの public API を一時的に変更 → `apiCheck` が drift を検出して FAIL することをローカル確認 (検証後 revert)
- [ ] 既存 `(cd integrationTest && ./gradlew jvmTest)` 等のテストに不影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)