### PR TITLE
fix(compiler-plugin): drop @ComposePreviewLabOption(ignore=true) previews from cross-module hint discovery

### DIFF
--- a/annotation/src/commonMain/kotlin/me/tbsten/compose/preview/lab/ComposePreviewLabOption.kt
+++ b/annotation/src/commonMain/kotlin/me/tbsten/compose/preview/lab/ComposePreviewLabOption.kt
@@ -32,7 +32,7 @@ package me.tbsten.compose.preview.lab
  * - {{qualifiedName}} ... the fully qualified name of the Preview, e.g. `com.example.my.buttons.MyButtonPreviewKt.MyButtonPreview` if the Preview is defined in a file named `MyButtonPreview.kt`.
  *
  * @property displayName {{package}}, {{simpleName}}, {{qualifiedName}} or a custom string. It does not have to match other Previews as it does not function like an ID. `. Each segment separated by ` is considered a group.
- * @property ignore if true, Compose Preview Lab Gradle Plugin don't collect this Preview.
+ * @property ignore if true, Compose Preview Lab does not collect this Preview. The exclusion applies in both directions: the same module's `collectModulePreviews()` drops it via the IR-side filter, and consumer modules' `collectAllModulePreviews()` cannot discover it because no per-declaration hint is emitted in the first place.
  * @property id An ID to identify each Preview. It can be used for navigation within the PreviewLabNavController. The same placeholder as displayName can be used.
  */
 @Retention(AnnotationRetention.BINARY)

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewHintFirGenerator.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewHintFirGenerator.kt
@@ -9,6 +9,8 @@ import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
+import org.jetbrains.kotlin.fir.declarations.getBooleanArgument
+import org.jetbrains.kotlin.fir.declarations.toAnnotationClassIdSafe
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationGenerationExtension
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
 import org.jetbrains.kotlin.fir.extensions.MemberGenerationContext
@@ -112,6 +114,21 @@ internal class PreviewHintFirGenerator(session: FirSession) : FirDeclarationGene
     }
 
     /**
+     * Auxiliary predicate that pulls `@ComposePreviewLabOption` into the FIR
+     * predicate-based provider's resolved annotation set.
+     *
+     * Without this, the annotation's `annotationTypeRef` stays unresolved on `@Preview`
+     * symbols during STATUS phase: `toAnnotationClassIdSafe(session)` then returns null
+     * for the option annotation, even after `lazyResolveToPhase(ANNOTATION_ARGUMENTS)`.
+     * Registering the predicate signals the resolver that this annotation type must be
+     * eagerly resolved on every symbol it appears on, so [computeHintEntries] can read
+     * `ignore = true` reliably.
+     */
+    private val optionPredicate: LookupPredicate = LookupPredicate.create {
+        annotated(PreviewLabFirBuiltIns.COMPOSE_PREVIEW_LAB_OPTION_FQN)
+    }
+
+    /**
      * One entry per `@Preview` discovered in this session, tying it to its marker / hint
      * pair. Walked the first time [getTopLevelCallableIds] / [getTopLevelClassIds] is
      * touched (never inside a cache loader).
@@ -125,6 +142,7 @@ internal class PreviewHintFirGenerator(session: FirSession) : FirDeclarationGene
 
     override fun FirDeclarationPredicateRegistrar.registerPredicates() {
         register(previewPredicate)
+        register(optionPredicate)
     }
 
     override fun getTopLevelClassIds(): Set<ClassId> = hintEntries.mapTo(mutableSetOf()) { entry ->
@@ -250,6 +268,16 @@ internal class PreviewHintFirGenerator(session: FirSession) : FirDeclarationGene
      * Walks the predicate and computes the hint hash plus marker class short name for each
      * `@Preview` function.
      *
+     * **Behavior on `@ComposePreviewLabOption(ignore = true)`**: such `@Preview` symbols are
+     * filtered out *before* hint emission, so neither the marker interface nor the
+     * `previewHint` overload is generated for them. Cross-module consumers therefore cannot
+     * discover ignored previews via `referenceFunctions`. The annotation argument is read
+     * via `resolvedAnnotationsWithArguments` (lazy advance to `ANNOTATION_ARGUMENTS` phase),
+     * preferring the stdlib `getBooleanArgument` helper but falling back to a manual walk of
+     * the raw `argumentList.arguments` when the resolved name → expression mapping is empty
+     * (a state observed for inherit-classpath builds in our kctfork tests). See
+     * [isIgnoredByComposePreviewLabOption] for the readout details.
+     *
      * Evaluated lazily the first time [getTopLevelClassIds] / [getTopLevelCallableIds] is
      * touched.
      */
@@ -258,6 +286,7 @@ internal class PreviewHintFirGenerator(session: FirSession) : FirDeclarationGene
         return symbols
             .filterIsInstance<FirNamedFunctionSymbol>()
             .filter { it.callableId.classId == null }
+            .filterNot { symbol -> symbol.isIgnoredByComposePreviewLabOption() }
             .map { symbol ->
                 val callableId = symbol.callableId
                 val packageName = callableId.packageName.asString()
@@ -272,6 +301,94 @@ internal class PreviewHintFirGenerator(session: FirSession) : FirDeclarationGene
                 )
             }
             .distinctBy { it.markerShortName }
+    }
+
+    /**
+     * Index of `ignore` in the `@ComposePreviewLabOption(displayName, ignore, id)` parameter
+     * list. Used by [isIgnoredByComposePreviewLabOption] when walking unnamed positional
+     * arguments — only the literal at this index is interpreted as `ignore`, so future
+     * additions of other `Boolean` parameters cannot accidentally flip the readout.
+     */
+    private val ignoreParameterIndex: Int = 1
+
+    /**
+     * Returns true when the `@Preview` symbol also carries
+     * `@ComposePreviewLabOption(ignore = true)`. Used by [computeHintEntries] to skip
+     * ignored previews up front, so neither the marker interface nor the `previewHint`
+     * overload is emitted for them.
+     *
+     * **Behavior**:
+     * ```kotlin
+     * @Preview
+     * @ComposePreviewLabOption(ignore = true)
+     * fun Hidden()                                 // → true   (filtered out)
+     *
+     * @Preview
+     * fun Plain()                                  // → false  (no option annotation)
+     *
+     * @Preview
+     * @ComposePreviewLabOption(displayName = "X")  // → false  (`ignore` omitted, default false)
+     * fun Named()
+     * ```
+     *
+     * # Why the manual argument walk
+     *
+     * The stdlib `getBooleanArgument` helper relies on the resolved
+     * `argumentMapping.mapping` (name → expression) populated during the
+     * `ANNOTATION_ARGUMENTS` resolve phase. In practice — and in particular when the
+     * generator runs on a source build that has `@ComposePreviewLabOption` declared in
+     * the same module's `inheritClassPath` — the named mapping is empty even after
+     * `lazyResolveToPhase(ANNOTATION_ARGUMENTS)`, while the raw `argumentList.arguments`
+     * does carry the literal. So the helper is tried first (cheap, correct when
+     * available) and a manual `FirLiteralExpression` cast off the raw argument list is
+     * the fallback.
+     *
+     * # Which argument forms are recognized
+     *
+     * - `(ignore = true)` — matched by `argumentName == IGNORE_NAME` and accepted regardless
+     *   of position.
+     * - `("X", true)` — positional Boolean literal at the slot reserved for `ignore`
+     *   ([ignoreParameterIndex]). Other positional indices are ignored even if they hold
+     *   a Boolean literal, so the readout cannot misfire if `ComposePreviewLabOption` ever
+     *   gains another `Boolean` parameter elsewhere in the parameter list.
+     * - `(true)` alone — does not compile (the preceding `displayName: String` has no
+     *   default that can be skipped positionally), so this case never occurs in practice.
+     */
+    private fun FirNamedFunctionSymbol.isIgnoredByComposePreviewLabOption(): Boolean {
+        lazyResolveToPhase(FirResolvePhase.ANNOTATION_ARGUMENTS)
+        val optionAnnotation = resolvedAnnotationsWithArguments
+            .firstOrNull { it.toAnnotationClassIdSafe(session) == PreviewLabFirBuiltIns.COMPOSE_PREVIEW_LAB_OPTION_CLASS_ID }
+            ?: return false
+
+        // Fast path: stdlib helper using the resolved name → expression mapping. Returns
+        // null when the mapping is empty (common in our tests' inherit-classpath setup),
+        // which falls through to the manual argument walk below.
+        optionAnnotation.getBooleanArgument(PreviewLabFirBuiltIns.IGNORE_NAME, session)?.let { return it }
+
+        // Fallback: walk the raw argument list. Accepts named (`ignore = true`) directly,
+        // and positional Boolean literals only when they sit in the `ignore` parameter
+        // slot ([ignoreParameterIndex]). This guards against future `ComposePreviewLabOption`
+        // signature changes that might add another Boolean parameter.
+        val annotationCall = optionAnnotation as? org.jetbrains.kotlin.fir.expressions.FirAnnotationCall
+            ?: return false
+        for ((argumentIndex, argument) in annotationCall.argumentList.arguments.withIndex()) {
+            val (argumentName, argumentExpression) = when (argument) {
+                is org.jetbrains.kotlin.fir.expressions.FirNamedArgumentExpression ->
+                    argument.name to argument.expression
+                else -> null to argument
+            }
+            val isIgnoreArgument = when {
+                argumentName == PreviewLabFirBuiltIns.IGNORE_NAME -> true
+                argumentName != null -> false // some other named argument
+                else -> argumentIndex == ignoreParameterIndex // positional fallback
+            }
+            if (!isIgnoreArgument) continue
+            val literal = argumentExpression as? org.jetbrains.kotlin.fir.expressions.FirLiteralExpression
+                ?: continue
+            val booleanValue = literal.value as? Boolean ?: continue
+            return booleanValue
+        }
+        return false
     }
 
     /**

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewLabFirBuiltIns.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewLabFirBuiltIns.kt
@@ -63,6 +63,25 @@ internal class PreviewLabFirBuiltIns(session: FirSession, val config: PluginConf
         /** Android `@Preview` annotation FQN (used for predicate registration). */
         val ANDROID_PREVIEW_ANNOTATION_FQN: FqName =
             FqName("androidx.compose.ui.tooling.preview.Preview")
+
+        /**
+         * `me.tbsten.compose.preview.lab.ComposePreviewLabOption` FQN — used both for FIR
+         * `LookupPredicate` registration (eagerly resolves the annotation type ref) and as
+         * the source of [COMPOSE_PREVIEW_LAB_OPTION_CLASS_ID].
+         */
+        val COMPOSE_PREVIEW_LAB_OPTION_FQN: FqName =
+            FqName("me.tbsten.compose.preview.lab.ComposePreviewLabOption")
+
+        /**
+         * `me.tbsten.compose.preview.lab.ComposePreviewLabOption` `ClassId` — looked up on
+         * each `@Preview` symbol to read user-supplied options (e.g. `ignore = true`) during
+         * hint emission.
+         */
+        val COMPOSE_PREVIEW_LAB_OPTION_CLASS_ID: ClassId =
+            ClassId.topLevel(COMPOSE_PREVIEW_LAB_OPTION_FQN)
+
+        /** `@ComposePreviewLabOption(ignore = ...)` argument name. */
+        val IGNORE_NAME: Name = Name.identifier("ignore")
     }
 }
 

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewHintIrBodyFiller.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewHintIrBodyFiller.kt
@@ -59,11 +59,13 @@ import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
  *   unambiguous.
  * - **`CollectedPreview` construction**: reuses the existing
  *   [CollectedPreviewIrBuilder.buildCollectedPreviewCall] unchanged.
- * - **`@ComposePreviewLabOption(ignore = true)` handling**: hint emission runs even for
- *   ignore=true, so the IR side likewise walks every `@Preview` in the moduleFragment
- *   (rather than the filtered `previews`) when building `PreviewFunctionInfo`. Otherwise
- *   the ignore=true hint is left orphan (body=null), which trips a JVM backend assert.
- *   Hiding ignored previews on the cross-module side is tracked as a separate follow-up.
+ * - **`@ComposePreviewLabOption(ignore = true)` handling**: the FIR generator filters
+ *   ignored previews out *before* emitting any hint declaration, so the IR-side body
+ *   filler does the same — `previewsByHash` is built from the filtered `previews` list,
+ *   and the few hint stubs that exist after the FIR pass are guaranteed to have a
+ *   matching entry. This also keeps ignored previews out of the hash collision check
+ *   (avoiding false positives between an ignored preview and an emitted preview that
+ *   share the same truncated SHA-256 hash).
  */
 internal class PreviewHintIrBodyFiller(
     private val pluginContext: IrPluginContext,
@@ -144,10 +146,12 @@ internal class PreviewHintIrBodyFiller(
  * Walks every `@Preview`-annotated top-level function in the module fragment and builds a
  * map from canonical-key hash to [PreviewFunctionInfo].
  *
- * Includes `ignore = true` previews so that every hint declaration emitted by
- * [PreviewHintFirGenerator] can have its body filled. The ignore filter is meant to be
- * applied on the consumer side (a follow-up tracks not exposing ignored previews
- * cross-module).
+ * Callers should pass an already-filtered `previews` list (i.e. with
+ * `@ComposePreviewLabOption(ignore = true)` removed). The FIR generator filters ignored
+ * previews out before emitting any hint declaration, so this map only needs entries for
+ * the previews that have a corresponding emitted hint stub. Including ignored previews
+ * here would also bloat the hash-collision check (raising the chance of a false-positive
+ * ERROR between an ignored preview and an emitted preview that share a truncated hash).
  *
  * The canonical key includes both `sourceFqn` and the parameter-type FQNs so that
  * same-name overloads (`fun MyButton()` vs `fun MyButton(text: String)`) are
@@ -165,8 +169,8 @@ internal class PreviewHintIrBodyFiller(
  * ERROR.
  *
  * Detection compares **canonical keys directly**, not FQN, so same-name overloads cannot
- * be misclassified. Re-registering the same canonical key (e.g. two passes once before
- * and once after the ignore=true filter) is not a collision and silently overwrites.
+ * be misclassified. Re-registering the same canonical key is not a collision and silently
+ * overwrites.
  */
 internal fun buildPreviewByHashMap(
     previews: List<PreviewFunctionInfo>,

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewLabIrGenerationExtension.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewLabIrGenerationExtension.kt
@@ -50,11 +50,16 @@ class PreviewLabIrGenerationExtension(
         // `previewHint(value: PreviewHintMarker_<hash>?): CollectedPreview` emitted by the
         // FIR generator (the function name is fixed to `previewHint`; the hash is
         // recovered from the marker class short name).
-        // Hint emission does not filter `ignore=true`, so the lookup used by the body
-        // filler must include ignored previews too.
+        //
+        // Since the FIR generator skips `@ComposePreviewLabOption(ignore = true)` previews
+        // before emitting any hint declaration, we must NOT include ignored previews in the
+        // hash → preview map either: doing so would let an ignored preview's hash sit in
+        // the map without a corresponding emitted hint, raising the chance that a future
+        // emitted preview's truncated SHA-256 hash collides with an ignored preview's hash
+        // and produces a false-positive collision ERROR. `collectPreviews` already excludes
+        // ignored entries.
         if (compatContext.supportsKlibCrossModuleHint()) {
-            val previewsIncludingIgnored = collectPreviewsIncludingIgnored(moduleFragment)
-            val previewsByHash = buildPreviewByHashMap(previewsIncludingIgnored) { hash, existing, conflicting ->
+            val previewsByHash = buildPreviewByHashMap(previews) { hash, existing, conflicting ->
                 val existingSignature = existing.function.canonicalSignatureForReport()
                 val conflictingSignature = conflicting.function.canonicalSignatureForReport()
                 val message = "[ComposePreviewLab] hint hash collision detected on `$hash`. " +
@@ -94,23 +99,6 @@ class PreviewLabIrGenerationExtension(
             }
         }
         return result.sortedBy { it.displayName }
-    }
-
-    /**
-     * Collects every `@Preview`-annotated function including those marked
-     * `@ComposePreviewLabOption(ignore = true)`. The per-declaration hint body filler must
-     * fill the body even for `ignore = true`, so it uses this function instead of the
-     * filtered [collectPreviews].
-     */
-    private fun collectPreviewsIncludingIgnored(moduleFragment: IrModuleFragment): List<PreviewFunctionInfo> {
-        val result = mutableListOf<PreviewFunctionInfo>()
-        for (file in moduleFragment.files) {
-            for (decl in file.declarations) {
-                if (decl !is IrSimpleFunction) continue
-                buildPreviewInfoOrNull(decl, includeIgnored = true)?.let { result.add(it) }
-            }
-        }
-        return result
     }
 
     /**

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/PreviewHintIgnoreCrossModuleTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/PreviewHintIgnoreCrossModuleTest.kt
@@ -1,0 +1,376 @@
+package me.tbsten.compose.preview.lab.compiler.feature
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import me.tbsten.compose.preview.lab.compiler.CompilerPluginTestBase
+import me.tbsten.compose.preview.lab.compiler.isAtLeast
+import me.tbsten.compose.preview.lab.compiler.loadCollectedPreviews
+import java.io.File
+
+/**
+ * Cross-module behaviour of `@ComposePreviewLabOption(ignore = true)`.
+ *
+ * `PreviewHintFirGenerator` reads the option in FIR and skips hint emission for ignored
+ * previews. This test verifies two angles:
+ *
+ * - **Discovery**: `collectAllModulePreviews()` on the app side never sees an ignored
+ *   preview from a dependency module.
+ * - **Emission**: the ignored preview's marker interface and `previewHint` function are
+ *   absent from the lib's compiled output (the filter runs *before* emission, not on the
+ *   consumer side).
+ *
+ * **Skipped on Kotlin < 2.3.21**: the per-declaration hint generator only runs on
+ * Kotlin 2.3.21+ ([CompatContext.supportsKlibCrossModuleHint]).
+ */
+class PreviewHintIgnoreCrossModuleTest :
+    FunSpec({
+        val base = CompilerPluginTestBase()
+
+        val testKotlinVersion = System.getProperty("test.kotlin.version") ?: "2.3.21"
+        val supports = testKotlinVersion.isAtLeast(2, 3, 21)
+
+        context("cross-module ignore filter (the core fix)") {
+            test("ignore=true preview from a dependency module is absent from collectAllModulePreviews()")
+                .config(enabled = supports) {
+                    val libResult = base.compile(
+                        SourceFile.kotlin(
+                            "UiLib.kt",
+                            """
+                            package uilib
+
+                            @org.jetbrains.compose.ui.tooling.preview.Preview
+                            @me.tbsten.compose.preview.lab.ComposePreviewLabOption(ignore = true)
+                            fun Hidden() {}
+
+                            @org.jetbrains.compose.ui.tooling.preview.Preview
+                            fun Visible() {}
+                            """,
+                        ),
+                    )
+                    libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                    val appCompileResult = base.compile(
+                        SourceFile.kotlin(
+                            "App.kt",
+                            """
+                            package app
+                            """,
+                        ),
+                        base.collectAllModulePreviewsEntry("allPreviews"),
+                        extraClasspaths = listOf(libResult.outputDirectory),
+                    )
+                    appCompileResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                    val ids = appCompileResult.loadCollectedPreviews(propertyName = "allPreviews").previewIds()
+                    ids shouldContainExactlyInAnyOrder listOf("uilib.Visible")
+                }
+
+            test("ignore=true preview emits no previewHint overload into the lib classpath")
+                .config(enabled = supports) {
+                    val libResult = base.compile(
+                        SourceFile.kotlin(
+                            "UiLib.kt",
+                            """
+                            package uilib
+
+                            @org.jetbrains.compose.ui.tooling.preview.Preview
+                            @me.tbsten.compose.preview.lab.ComposePreviewLabOption(ignore = true)
+                            fun Hidden() {}
+
+                            @org.jetbrains.compose.ui.tooling.preview.Preview
+                            fun Visible() {}
+                            """,
+                        ),
+                    )
+                    libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                    // Exactly one PreviewHint_<hash>.class facade is emitted (for `Visible`),
+                    // since `Hidden` is filtered out before FIR generation.
+                    val hintFacades = libResult.outputDirectory.previewHintFacadeFiles()
+                    hintFacades.size shouldBe 1
+                }
+
+            test("ignore=true preview emits no marker interface into the lib classpath")
+                .config(enabled = supports) {
+                    val libResult = base.compile(
+                        SourceFile.kotlin(
+                            "UiLib.kt",
+                            """
+                            package uilib
+
+                            @org.jetbrains.compose.ui.tooling.preview.Preview
+                            @me.tbsten.compose.preview.lab.ComposePreviewLabOption(ignore = true)
+                            fun Hidden() {}
+
+                            @org.jetbrains.compose.ui.tooling.preview.Preview
+                            fun Visible() {}
+                            """,
+                        ),
+                    )
+                    libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                    val markers = libResult.outputDirectory.previewHintMarkerFiles()
+                    assertSoftly {
+                        markers.size shouldBe 1
+                        // The marker name embeds the sanitized FQN; the `Hidden` one would
+                        // contain "_Hidden_" if it were emitted.
+                        markers.none { it.nameWithoutExtension.contains("_Hidden_") } shouldBe true
+                        markers.singleOrNull()?.nameWithoutExtension?.contains("_Visible_") shouldBe true
+                    }
+                }
+
+            test("3 ignored + 2 visible -> app sees only 2 visible across the boundary")
+                .config(enabled = supports) {
+                    val libResult = base.compile(
+                        SourceFile.kotlin(
+                            "UiLib.kt",
+                            """
+                            package uilib
+
+                            @org.jetbrains.compose.ui.tooling.preview.Preview
+                            @me.tbsten.compose.preview.lab.ComposePreviewLabOption(ignore = true)
+                            fun H1() {}
+
+                            @org.jetbrains.compose.ui.tooling.preview.Preview
+                            @me.tbsten.compose.preview.lab.ComposePreviewLabOption(ignore = true)
+                            fun H2() {}
+
+                            @org.jetbrains.compose.ui.tooling.preview.Preview
+                            @me.tbsten.compose.preview.lab.ComposePreviewLabOption(ignore = true)
+                            fun H3() {}
+
+                            @org.jetbrains.compose.ui.tooling.preview.Preview
+                            fun V1() {}
+
+                            @org.jetbrains.compose.ui.tooling.preview.Preview
+                            fun V2() {}
+                            """,
+                        ),
+                    )
+                    libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                    val appCompileResult = base.compile(
+                        SourceFile.kotlin(
+                            "App.kt",
+                            """
+                            package app
+                            """,
+                        ),
+                        base.collectAllModulePreviewsEntry("allPreviews"),
+                        extraClasspaths = listOf(libResult.outputDirectory),
+                    )
+                    appCompileResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                    val ids = appCompileResult.loadCollectedPreviews(propertyName = "allPreviews").previewIds()
+                    ids shouldContainExactlyInAnyOrder listOf("uilib.V1", "uilib.V2")
+                }
+        }
+
+        context("annotation-argument variations") {
+            test("ignore=false (explicit) is emitted and discoverable cross-module")
+                .config(enabled = supports) {
+                    val libResult = base.compile(
+                        SourceFile.kotlin(
+                            "UiLib.kt",
+                            """
+                            package uilib
+
+                            @org.jetbrains.compose.ui.tooling.preview.Preview
+                            @me.tbsten.compose.preview.lab.ComposePreviewLabOption(ignore = false)
+                            fun ExplicitFalse() {}
+                            """,
+                        ),
+                    )
+                    libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                    val appCompileResult = base.compile(
+                        SourceFile.kotlin(
+                            "App.kt",
+                            """
+                            package app
+                            """,
+                        ),
+                        base.collectAllModulePreviewsEntry("allPreviews"),
+                        extraClasspaths = listOf(libResult.outputDirectory),
+                    )
+                    appCompileResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                    appCompileResult.loadCollectedPreviews(
+                        propertyName = "allPreviews"
+                    ).previewIds() shouldContainExactlyInAnyOrder
+                        listOf("uilib.ExplicitFalse")
+                }
+
+            test("option without ignore (default false) is emitted and discoverable cross-module")
+                .config(enabled = supports) {
+                    val libResult = base.compile(
+                        SourceFile.kotlin(
+                            "UiLib.kt",
+                            """
+                            package uilib
+
+                            @org.jetbrains.compose.ui.tooling.preview.Preview
+                            @me.tbsten.compose.preview.lab.ComposePreviewLabOption(displayName = "X")
+                            fun WithDisplayName() {}
+                            """,
+                        ),
+                    )
+                    libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                    val appCompileResult = base.compile(
+                        SourceFile.kotlin(
+                            "App.kt",
+                            """
+                            package app
+                            """,
+                        ),
+                        base.collectAllModulePreviewsEntry("allPreviews"),
+                        extraClasspaths = listOf(libResult.outputDirectory),
+                    )
+                    appCompileResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                    appCompileResult.loadCollectedPreviews(
+                        propertyName = "allPreviews"
+                    ).previewIds() shouldContainExactlyInAnyOrder
+                        listOf("uilib.WithDisplayName")
+                }
+
+            test("@Preview without @ComposePreviewLabOption is emitted and discoverable")
+                .config(enabled = supports) {
+                    val libResult = base.compile(
+                        SourceFile.kotlin(
+                            "UiLib.kt",
+                            """
+                            package uilib
+
+                            @org.jetbrains.compose.ui.tooling.preview.Preview
+                            fun Plain() {}
+                            """,
+                        ),
+                    )
+                    libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                    val appCompileResult = base.compile(
+                        SourceFile.kotlin(
+                            "App.kt",
+                            """
+                            package app
+                            """,
+                        ),
+                        base.collectAllModulePreviewsEntry("allPreviews"),
+                        extraClasspaths = listOf(libResult.outputDirectory),
+                    )
+                    appCompileResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                    appCompileResult.loadCollectedPreviews(
+                        propertyName = "allPreviews"
+                    ).previewIds() shouldContainExactlyInAnyOrder
+                        listOf("uilib.Plain")
+                }
+
+            test("ignore=true takes priority over displayName (no emission)")
+                .config(enabled = supports) {
+                    val libResult = base.compile(
+                        SourceFile.kotlin(
+                            "UiLib.kt",
+                            """
+                            package uilib
+
+                            @org.jetbrains.compose.ui.tooling.preview.Preview
+                            @me.tbsten.compose.preview.lab.ComposePreviewLabOption(ignore = true, displayName = "X")
+                            fun HiddenWithName() {}
+                            """,
+                        ),
+                    )
+                    libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                    val hintFacades = libResult.outputDirectory.previewHintFacadeFiles()
+                    val markers = libResult.outputDirectory.previewHintMarkerFiles()
+                    assertSoftly {
+                        hintFacades.shouldBeEmpty()
+                        markers.shouldBeEmpty()
+                    }
+                }
+        }
+
+        context("self-module regression (IR-side ignore filter independence)") {
+            // The IR-side ignore filter (independent of the FIR filter introduced here)
+            // keeps working — verify that single-module collectModulePreviews() /
+            // collectAllModulePreviews() still drop ignored entries.
+
+            test("self-module collectModulePreviews() still drops ignore=true previews") {
+                val result = base.compile(
+                    SourceFile.kotlin(
+                        "Self.kt",
+                        """
+                        package self
+
+                        @org.jetbrains.compose.ui.tooling.preview.Preview
+                        @me.tbsten.compose.preview.lab.ComposePreviewLabOption(ignore = true)
+                        fun Hidden() {}
+
+                        @org.jetbrains.compose.ui.tooling.preview.Preview
+                        fun Visible() {}
+                        """,
+                    ),
+                    base.collectModulePreviewsEntry(),
+                )
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+                result.loadCollectedPreviews().previewIds() shouldContainExactlyInAnyOrder listOf("self.Visible")
+            }
+
+            test("self-module collectAllModulePreviews() also drops own ignore=true previews")
+                .config(enabled = supports) {
+                    val result = base.compile(
+                        SourceFile.kotlin(
+                            "Self.kt",
+                            """
+                            package self
+
+                            @org.jetbrains.compose.ui.tooling.preview.Preview
+                            @me.tbsten.compose.preview.lab.ComposePreviewLabOption(ignore = true)
+                            fun Hidden() {}
+
+                            @org.jetbrains.compose.ui.tooling.preview.Preview
+                            fun Visible() {}
+                            """,
+                        ),
+                        base.collectAllModulePreviewsEntry("allPreviews"),
+                    )
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+                    result.loadCollectedPreviews(propertyName = "allPreviews").previewIds() shouldContainExactlyInAnyOrder
+                        listOf("self.Visible")
+                }
+        }
+    })
+
+private fun List<Any>.previewIds(): List<String> = map { p ->
+    p::class.members.find { it.name == "id" }!!.call(p) as String
+}
+
+/**
+ * Walks the lib output directory for `PreviewHint_<hash>Kt.class` facade files (the file
+ * facade emitted by [PreviewHintFirGenerator.generateFunctions]). One file per per-declaration
+ * hint — so we can check that ignored previews leave no facade behind.
+ */
+private fun File.previewHintFacadeFiles(): List<File> = walkTopDown()
+    .filter { it.isFile && it.extension == "class" }
+    .filter {
+        it.parentFile.toRelativeString(this).replace('/', '.').replace('\\', '.') == "me.tbsten.compose.preview.lab.hints"
+    }
+    .filter { it.name.startsWith("PreviewHint_") && it.name.endsWith("Kt.class") }
+    .toList()
+
+/** Walks the lib output for `PreviewHintMarker_<sanitized_fqn>_<hash>.class` files. */
+private fun File.previewHintMarkerFiles(): List<File> = walkTopDown()
+    .filter { it.isFile && it.extension == "class" }
+    .filter {
+        it.parentFile.toRelativeString(this).replace('/', '.').replace('\\', '.') == "me.tbsten.compose.preview.lab.hints"
+    }
+    .filter { it.name.startsWith("PreviewHintMarker_") && !it.name.endsWith("Kt.class") }
+    .toList()


### PR DESCRIPTION
## Summary

- Filter out `@ComposePreviewLabOption(ignore = true)` previews **at the FIR generator step** so neither the marker interface nor the `previewHint` overload is emitted for them — closing the cross-module leak called out on PR #170 / #171 / #172.
- The annotation argument is read with stdlib `getBooleanArgument` first, then a manual raw-`argumentList` walk as fallback (named/positional Boolean literal). A second `LookupPredicate` for `@ComposePreviewLabOption` is registered so the annotation's `annotationTypeRef` actually resolves on every `@Preview` symbol during STATUS phase.
- KDoc on `ComposePreviewLabOption.ignore` now spells out that the exclusion applies to both `collectModulePreviews()` and `collectAllModulePreviews()`.

Refs: `.local/ticket/followup-ignore-preview-cross-module-leak.md`

## Test plan

- [x] `./gradlew :compiler-plugin:test` — 84 tests, all green (10 new tests in `PreviewHintIgnoreCrossModuleTest` + existing 74)
- [x] `./gradlew :compiler-plugin:ktlintCheck`
- [x] `./gradlew :compiler-plugin:apiCheck` / `:annotation:apiCheck` — no drift
- [x] `(cd integrationTest && ./gradlew jvmTest)` — green
- [ ] CI multi-Kotlin-version matrix (2.1.20 / 2.2.x / 2.3.21 / 2.4.0-Beta2)
- [ ] CI all KMP targets (jsBrowserTest / wasmJsBrowserTest / iosSimulatorArm64Test / testDebugUnitTest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)