### PR TITLE
test(compiler-plugin): prove sealed-ization is redundant under @Deprecated(HIDDEN)

### DIFF
--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewHintFirGenerator.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewHintFirGenerator.kt
@@ -162,17 +162,18 @@ internal class PreviewHintFirGenerator(session: FirSession, private val compat: 
      * Compose Compiler's `$stableprop` synthesis (which causes JS / Wasm IC collisions)
      * and Konan's `Expected a class, found interface` error (which rejects FINAL modality
      * on interfaces).
+     *
+     * The marker is **not** declared `sealed`. The `@Deprecated(HIDDEN)` annotation
+     * applied below already removes the symbol from consumer-side scope resolution, so
+     * an external `class MyMarker : PreviewHintMarker_<sanitized_fqn>_<hash>` does not
+     * compile — sealed-ization would be redundant. See
+     * `PreviewHintMarkerSealOrHiddenTest` for the executable proof.
      */
     override fun generateTopLevelClassLikeDeclaration(classId: ClassId): FirClassLikeSymbol<*>? {
         if (classId.packageFqName != PreviewLabFirBuiltIns.HINT_PACKAGE) return null
         val shortName = classId.shortClassName.asString()
         if (shortName !in hashByMarkerShortName) return null
 
-        // TODO: the marker is purely internal (its only purpose is to disambiguate the
-        //   IdSignature per `@Preview`), so it should switch to `Modality.SEALED` to lock out
-        //   external implementations. Deferred because `sealed` + `@Deprecated(HIDDEN)` needs
-        //   cross-Kotlin-version (2.1 through 2.4-Beta) and KLIB IC validation.
-        //   follow-up: .local/ticket/followup-sealed-hint-marker-interface.md
         val klass = createTopLevelClass(classId, Keys.PreviewLabHintMarkerInterface, ClassKind.INTERFACE) {
             modality = Modality.ABSTRACT
         }

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/PreviewHintMarkerSealOrHiddenTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/PreviewHintMarkerSealOrHiddenTest.kt
@@ -1,0 +1,126 @@
+package me.tbsten.compose.preview.lab.compiler.feature
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import me.tbsten.compose.preview.lab.compiler.CompilerPluginTestBase
+import me.tbsten.compose.preview.lab.compiler.isAtLeast
+import java.io.File
+
+/**
+ * Records the answer to "should the per-declaration marker interface be `sealed`?"
+ * via executable evidence rather than a doc-only verdict.
+ *
+ * **Background**: PR #176 review suggested making the marker `sealed` so external
+ * modules cannot implement it. PR #180 (the immediate parent of this branch) instead
+ * attaches `@Deprecated(level = HIDDEN)` to every marker, which removes the symbol
+ * from scope-based name resolution in consumer modules.
+ *
+ * The sealed-ization follow-up
+ * (`.local/ticket/followup-sealed-hint-marker-interface.md`) is the open question:
+ * *given* `@Deprecated(HIDDEN)`, does a consumer attempting `class X : PreviewHintMarker_<...>`
+ * already fail to compile? If yes, sealing the marker is redundant — close the
+ * ticket as wontfix. If no, follow up with the actual sealed-modality change.
+ *
+ * The first test below closes the question by asserting that the consumer compile
+ * does fail with a "is invisible" / "is hidden" diagnostic when it tries to extend
+ * a HIDDEN-deprecated marker. The second test serves as a positive control: an
+ * un-related class with no inheritance compiles without trouble.
+ *
+ * **Skipped on Kotlin < 2.3.21**: per-declaration hint generation only runs on Kotlin
+ * 2.3.21 and later, so the question this test answers does not apply on older versions.
+ */
+class PreviewHintMarkerSealOrHiddenTest :
+    FunSpec({
+        val base = CompilerPluginTestBase()
+
+        val testKotlinVersion = System.getProperty("test.kotlin.version") ?: "2.3.21"
+        val supports = testKotlinVersion.isAtLeast(2, 3, 21)
+
+        test("HIDDEN alone keeps consumers from extending the marker (sealed-ization is redundant)")
+            .config(enabled = supports) {
+                // Stage 1: lib emits PreviewHintMarker_uilib_Foo_<hash>.
+                val libResult = base.compile(
+                    SourceFile.kotlin(
+                        "UiLib.kt",
+                        """
+                        package uilib
+
+                        @org.jetbrains.compose.ui.tooling.preview.Preview
+                        fun Foo() {}
+                        """,
+                    ),
+                )
+                libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                val markerFqn = libResult.outputDirectory.singleHintMarkerFqn()
+
+                // Stage 2: a consumer module tries to extend the marker. Without HIDDEN
+                // this would compile cleanly (the marker is `public abstract interface`).
+                // With HIDDEN, name resolution should reject the reference outright.
+                val appResult = base.compile(
+                    SourceFile.kotlin(
+                        "App.kt",
+                        """
+                        package app
+
+                        class MyMarker : $markerFqn
+                        """,
+                    ),
+                    extraClasspaths = listOf(libResult.outputDirectory),
+                )
+
+                // The compile must end in a *user-facing* compile error, not an
+                // internal compiler crash — `INTERNAL_ERROR` would also satisfy a plain
+                // `shouldNotBe OK`, and it might mask a regression where the plugin
+                // throws inside the FIR generator. Pin to `COMPILATION_ERROR` so the
+                // wider symptom (compile failure of any flavour) cannot accidentally
+                // satisfy this test.
+                appResult.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                // Different Kotlin patches phrase the diagnostic slightly differently
+                // ("is invisible" / "is hidden" / "Cannot access ..."); we accept any of
+                // the canonical wordings so this test stays green across the supported
+                // version range.
+                val msg = appResult.messages
+                val canonicalErrorPhrases = listOf("invisible", "hidden", "cannot access", "deprecated")
+                val matched = canonicalErrorPhrases.any { phrase ->
+                    msg.contains(phrase, ignoreCase = true)
+                }
+                matched shouldBe true
+            }
+
+        test("control: consumer that does NOT touch the marker still compiles")
+            .config(enabled = supports) {
+                // Sanity check: HIDDEN should *only* gate references to the marker, not
+                // the entire dependency. If this were to fail, the test above would
+                // catch a false positive.
+                val libResult = base.compile(
+                    SourceFile.kotlin(
+                        "UiLib.kt",
+                        """
+                        package uilib
+
+                        @org.jetbrains.compose.ui.tooling.preview.Preview
+                        fun Foo() {}
+                        """,
+                    ),
+                )
+                libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                val appResult = base.compile(
+                    SourceFile.kotlin(
+                        "App.kt",
+                        """
+                        package app
+
+                        class Plain
+                        """,
+                    ),
+                    extraClasspaths = listOf(libResult.outputDirectory),
+                )
+                appResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+    })
+
+private fun File.singleHintMarkerFqn(): String = previewHintMarkerNames().single()


### PR DESCRIPTION
## Summary

- Records the answer to the open `Modality.SEALED` follow-up question via an executable test rather than a doc-only verdict.
- `PreviewHintMarkerSealOrHiddenTest` asserts that a consumer module trying `class MyMarker : PreviewHintMarker_<...>` no longer compiles (HIDDEN gates name resolution); a control test confirms a plain consumer that does NOT touch the marker still compiles cleanly.
- KDoc on `generateTopLevelClassLikeDeclaration` is updated to point at the proof and the inline `// TODO: sealed` comment is dropped. Closing `.local/ticket/followup-sealed-hint-marker-interface.md` as **wontfix**.

Stacked on top of #180. Merge that one first.

Refs: `.local/ticket/followup-sealed-hint-marker-interface.md`

## Test plan

- [x] `./gradlew :compiler-plugin:test --tests *PreviewHintMarkerSealOrHiddenTest*` — 2 tests, both green
- [x] `./gradlew :compiler-plugin:ktlintCheck`
- [x] `./gradlew :compiler-plugin:test` (full suite) — green
- [ ] CI multi-Kotlin-version matrix — verifies the canonical-error-phrase tolerance across patches

🤖 Generated with [Claude Code](https://claude.com/claude-code)