### PR TITLE
chore(ci): enable --warning-mode all to surface Gradle 9 deprecation locations

### DIFF
--- a/.github/workflows/pbt-nightly.yml
+++ b/.github/workflows/pbt-nightly.yml
@@ -62,20 +62,20 @@ jobs:
 
       - name: Run Library PBT
         shell: bash
-        run: ./gradlew jvmTest -Dkotest.tags="PBT"
+        run: ./gradlew jvmTest -Dkotest.tags="PBT" --warning-mode all
 
       - name: Publish to Maven Local
         if: matrix.kotlin_version
         shell: bash
-        run: ./gradlew publishToMavenLocal
+        run: ./gradlew publishToMavenLocal --warning-mode all
 
       - name: Run Integration Test PBT
         shell: bash
-        run: cd ./integrationTest && ./gradlew :app:jvmTest -Dkotest.tags="PBT" -Ptest.property.iterations=${{ inputs.iterations || '5000' }}
+        run: cd ./integrationTest && ./gradlew :app:jvmTest -Dkotest.tags="PBT" -Ptest.property.iterations=${{ inputs.iterations || '5000' }} --warning-mode all
 
       - name: Run Docs PBT
         shell: bash
-        run: cd ./docs && ./gradlew jvmTest -Dkotest.tags="PBT" -Ptest.property.iterations=${{ inputs.iterations || '5000' }}
+        run: cd ./docs && ./gradlew jvmTest -Dkotest.tags="PBT" -Ptest.property.iterations=${{ inputs.iterations || '5000' }} --warning-mode all
 
   notify-failure:
     needs: pbt

--- a/.github/workflows/preview-web.yml
+++ b/.github/workflows/preview-web.yml
@@ -22,7 +22,7 @@ jobs:
         id: get_version
         run: echo "version=$(./gradlew -q logVersion)" >> "$GITHUB_OUTPUT"
       - name: Build Dokka Documentation
-        run: ./gradlew :dokkaDocs:dokkaGenerate
+        run: ./gradlew :dokkaDocs:dokkaGenerate --warning-mode all
       - name: Save version
         run: echo "${{ steps.get_version.outputs.version }}" > ./version.txt
       - name: Upload Dokka artifacts
@@ -63,7 +63,7 @@ jobs:
           safe-chain setup-ci
       - run: mkdir -p ./public
       - name: Build PreviewLabGallery JS contents
-        run: cd docs && ./gradlew :sample:buildProductionPreviewLabGallery
+        run: cd docs && ./gradlew :sample:buildProductionPreviewLabGallery --warning-mode all
       - name: Build Docusaurus
         run: cd docs/web && npm ci && npm run build
       - name: Copy web documentation to public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Publish to MavenCentral
-        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
+        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache --warning-mode all
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,7 +25,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
       - name: Run Lint
         shell: bash
-        run: ./gradlew ktlintCheck
+        run: ./gradlew ktlintCheck --warning-mode all
   validate-binary-compatibility:
     name: Validate Binary Compatibility
     runs-on: ubuntu-latest
@@ -41,11 +41,11 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
       - name: Validate Binary Compatibility
         shell: bash
-        run: ./gradlew apiCheck
+        run: ./gradlew apiCheck --warning-mode all
       - name: Validate Binary Compatibility (integrationTest)
         working-directory: integrationTest
         shell: bash
-        run: ./gradlew apiCheck
+        run: ./gradlew apiCheck --warning-mode all
   test:
     strategy:
       fail-fast: false
@@ -89,14 +89,14 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
       - name: Test Library
         shell: bash
-        run: ./gradlew ${{ matrix.test_task }} ${{ matrix.kotest_tags && format('-Dkotest.tags="{0}"', matrix.kotest_tags) || '' }}
+        run: ./gradlew ${{ matrix.test_task }} ${{ matrix.kotest_tags && format('-Dkotest.tags="{0}"', matrix.kotest_tags) || '' }} --warning-mode all
       - name: Test Integration Test
         shell: bash
-        run: cd ./integrationTest && ./gradlew ${{ matrix.test_task }} ${{ matrix.kotest_tags && format('-Dkotest.tags="{0}"', matrix.kotest_tags) || '' }}
+        run: cd ./integrationTest && ./gradlew ${{ matrix.test_task }} ${{ matrix.kotest_tags && format('-Dkotest.tags="{0}"', matrix.kotest_tags) || '' }} --warning-mode all
       - name: Test Docs
         if: matrix.test_task == 'jvmTest'
         shell: bash
-        run: cd ./docs && ./gradlew jvmTest ${{ matrix.kotest_tags && format('-Dkotest.tags="{0}"', matrix.kotest_tags) || '' }}
+        run: cd ./docs && ./gradlew jvmTest ${{ matrix.kotest_tags && format('-Dkotest.tags="{0}"', matrix.kotest_tags) || '' }} --warning-mode all
   # Expand the supported Kotlin versions from the SSOT (scripts/supported-kotlin-versions.txt).
   resolve-supported-kotlin-versions:
     name: Resolve Kotlin compat versions
@@ -148,4 +148,4 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
       - name: Publish to Maven Local
         shell: bash
-        run: ./gradlew publishToMavenLocal
+        run: ./gradlew publishToMavenLocal --warning-mode all


### PR DESCRIPTION
## Summary

`.github/workflows/` 配下の `./gradlew` 呼び出しに `--warning-mode all` を追加し、 Gradle 9
互換性に影響する deprecation warning の **個別 source location** を CI ログから可視化する。

## Why

CI ログに `Deprecated Gradle features were used in this build` という aggregated count しか
出ておらず、 個別の `<file>:<line>` が取れない。 今後の Kotlin / AGP / Gradle upgrade 作業で
deprecation baseline が比較できず silent regression のリスク。

## Changes

| File | 対象 step |
|------|----------|
| `pull-request.yml` | ktlintCheck / apiCheck (root + integrationTest) / test matrix (library / integrationTest / docs) / publishToMavenLocal |
| `pbt-nightly.yml` | library PBT / publishToMavenLocal / integrationTest PBT / docs PBT |
| `preview-web.yml` | dokkaGenerate / sample preview-lab-gallery build |
| `publish.yml` | publishAndReleaseToMavenCentral |

`preview-web.yml` の `./gradlew -q logVersion` step は **意図的に skip** (`-q` quiet と
`--warning-mode all` 詳細出力が矛盾するため)。

## Test plan

- [ ] CI run で `Deprecated Gradle features were used` ログに具体的な source location (`<file>:<line>`) が表示されること
- [ ] 既存 build / test / lint が引き続き green
- [ ] CI 時間が大幅に伸びていない (= 1 分以内の増加)

## Refs

- Ticket: `.local/ticket/task-017-ci-warning-mode-all.md`
- 探索チケット: `#0084`

🤖 Generated with [Claude Code](https://claude.com/claude-code)