### PR TITLE
chore(integrationTest/bcv): exclude @ExperimentalComposePreviewLabApi signatures from baseline

### DIFF
--- a/integrationTest/build.gradle.kts
+++ b/integrationTest/build.gradle.kts
@@ -19,6 +19,11 @@ apiValidation {
         listOf(
             "me.tbsten.compose.preview.lab.InternalComposePreviewLabApi",
             "me.tbsten.compose.preview.lab.UiComposePreviewLabApi",
+            // Mirror root build.gradle.kts: experimental signatures are intentionally excluded
+            // from BCV baseline so experimental→stable promotions show up as concrete diffs.
+            // See root build.gradle.kts for the full Known Limitation note about the
+            // `@property:` JVM/Android asymmetric leak.
+            "me.tbsten.compose.preview.lab.ExperimentalComposePreviewLabApi",
         ),
     )
 


### PR DESCRIPTION
## Summary

`integrationTest/build.gradle.kts` の `apiValidation { nonPublicMarkers }` に
`me.tbsten.compose.preview.lab.ExperimentalComposePreviewLabApi` を追加し、 root
`build.gradle.kts` (PR #187 で導入済) と SoT を揃える。

## Why

PR #187 で root の `nonPublicMarkers` に Experimental marker を追加し、 baseline から
experimental signatures を除外した。 但し integrationTest は **独立 Gradle project**
(composite build ではない) のため、 root の `apiValidation` 設定は継承されず SoT 違反が
発生していた。 このまま放置すると将来 integrationTest 側で experimental API を消費した時に
baseline diff が integration / root で divergence する。

## Changes

- `integrationTest/build.gradle.kts` — `nonPublicMarkers.addAll(...)` に Experimental marker を 1 件追加。 既存 root の Known Limitation note (`@property:` JVM/Android asymmetric leak) は重複 drift を避けて comment 経由で reference

## Test plan

- [ ] `(cd integrationTest && ./gradlew apiCheck --continue)` green
- [ ] `(cd integrationTest && ./gradlew apiDump)` で baseline drift 無し (現在 integrationTest 配下 module は experimental API を expose していないため、 build.gradle.kts のみの diff)
- [ ] root と integrationTest の `nonPublicMarkers` 設定が同期している

## Refs

- Ticket: `.local/ticket/task-021-integrationtest-bcv-sot-propagation.md`
- 関連 commit (root 側): `51d35393` (PR #187), `87b81bfd` (Known Limitation note)
- 探索チケット: `#0142`

🤖 Generated with [Claude Code](https://claude.com/claude-code)