### PR TITLE
feat(annotation)!: gate ComposePreviewLabOption.Companion behind @ExperimentalComposePreviewLabApi

### DIFF
--- a/annotation/api/android/annotation.api
+++ b/annotation/api/android/annotation.api
@@ -1,12 +1,9 @@
 public abstract interface annotation class me/tbsten/compose/preview/lab/ComposePreviewLabOption : java/lang/annotation/Annotation {
-	public static final field Companion Lme/tbsten/compose/preview/lab/ComposePreviewLabOption$Companion;
+	public static final field DefaultCollectScope Ljava/lang/String;
 	public abstract fun collectScopes ()[Ljava/lang/String;
 	public abstract fun displayName ()Ljava/lang/String;
 	public abstract fun id ()Ljava/lang/String;
 	public abstract fun ignore ()Z
-}
-
-public final class me/tbsten/compose/preview/lab/ComposePreviewLabOption$Companion {
 }
 
 public abstract interface annotation class me/tbsten/compose/preview/lab/ExperimentalComposePreviewLabApi : java/lang/annotation/Annotation {

--- a/annotation/api/android/annotation.api
+++ b/annotation/api/android/annotation.api
@@ -1,5 +1,4 @@
 public abstract interface annotation class me/tbsten/compose/preview/lab/ComposePreviewLabOption : java/lang/annotation/Annotation {
-	public static final field DefaultCollectScope Ljava/lang/String;
 	public abstract fun collectScopes ()[Ljava/lang/String;
 	public abstract fun displayName ()Ljava/lang/String;
 	public abstract fun id ()Ljava/lang/String;

--- a/annotation/api/annotation.klib.api
+++ b/annotation/api/annotation.klib.api
@@ -15,8 +15,6 @@ open annotation class me.tbsten.compose.preview.lab/ComposePreviewLabOption : ko
         final fun <get-id>(): kotlin/String // me.tbsten.compose.preview.lab/ComposePreviewLabOption.id.<get-id>|<get-id>(){}[0]
     final val ignore // me.tbsten.compose.preview.lab/ComposePreviewLabOption.ignore|{}ignore[0]
         final fun <get-ignore>(): kotlin/Boolean // me.tbsten.compose.preview.lab/ComposePreviewLabOption.ignore.<get-ignore>|<get-ignore>(){}[0]
-
-    final object Companion // me.tbsten.compose.preview.lab/ComposePreviewLabOption.Companion|null[0]
 }
 
 open annotation class me.tbsten.compose.preview.lab/ExperimentalComposePreviewLabApi : kotlin/Annotation { // me.tbsten.compose.preview.lab/ExperimentalComposePreviewLabApi|null[0]

--- a/annotation/api/jvm/annotation.api
+++ b/annotation/api/jvm/annotation.api
@@ -1,12 +1,9 @@
 public abstract interface annotation class me/tbsten/compose/preview/lab/ComposePreviewLabOption : java/lang/annotation/Annotation {
-	public static final field Companion Lme/tbsten/compose/preview/lab/ComposePreviewLabOption$Companion;
+	public static final field DefaultCollectScope Ljava/lang/String;
 	public abstract fun collectScopes ()[Ljava/lang/String;
 	public abstract fun displayName ()Ljava/lang/String;
 	public abstract fun id ()Ljava/lang/String;
 	public abstract fun ignore ()Z
-}
-
-public final class me/tbsten/compose/preview/lab/ComposePreviewLabOption$Companion {
 }
 
 public abstract interface annotation class me/tbsten/compose/preview/lab/ExperimentalComposePreviewLabApi : java/lang/annotation/Annotation {

--- a/annotation/api/jvm/annotation.api
+++ b/annotation/api/jvm/annotation.api
@@ -1,5 +1,4 @@
 public abstract interface annotation class me/tbsten/compose/preview/lab/ComposePreviewLabOption : java/lang/annotation/Annotation {
-	public static final field DefaultCollectScope Ljava/lang/String;
 	public abstract fun collectScopes ()[Ljava/lang/String;
 	public abstract fun displayName ()Ljava/lang/String;
 	public abstract fun id ()Ljava/lang/String;

--- a/annotation/src/commonMain/kotlin/me/tbsten/compose/preview/lab/ComposePreviewLabOption.kt
+++ b/annotation/src/commonMain/kotlin/me/tbsten/compose/preview/lab/ComposePreviewLabOption.kt
@@ -171,7 +171,20 @@ annotation class ComposePreviewLabOption(
          *    so a library can pin all of its previews to a library-specific bucket without
          *    annotating each `@Preview`.
          * 3. If the Gradle DSL was not set either, the runtime default `"default"` applies.
+         *
+         * Both the surrounding `Companion` and this const carry
+         * `@ExperimentalComposePreviewLabApi` for **complementary** reasons:
+         * - the companion-level marker keeps the `Companion` *class* itself out of every
+         *   BCV baseline (KLIB/JVM/Android), so an empty companion does not lock-in as ABI
+         *   if the const ever moves elsewhere.
+         * - the const-level marker keeps the const *member* itself filtered: on KLIB this
+         *   nests with the companion-level filter, and on JVM/Android the const surfaces
+         *   directly as a `public static final field` on the outer `ComposePreviewLabOption`
+         *   class (the companion-level annotation does **not** propagate to that flattened
+         *   field — see the root build.gradle.kts Known Limitation note for details), so
+         *   without this marker the field stays in JVM/Android baselines forever.
          */
+        @ExperimentalComposePreviewLabApi
         public const val DefaultCollectScope: String = "default"
     }
 }

--- a/annotation/src/commonMain/kotlin/me/tbsten/compose/preview/lab/ComposePreviewLabOption.kt
+++ b/annotation/src/commonMain/kotlin/me/tbsten/compose/preview/lab/ComposePreviewLabOption.kt
@@ -138,6 +138,18 @@ annotation class ComposePreviewLabOption(
     @property:ExperimentalComposePreviewLabApi
     val collectScopes: Array<String> = [DefaultCollectScope],
 ) {
+    /**
+     * Companion object holding the [DefaultCollectScope] sentinel.
+     *
+     * **Experimental**: the whole companion is `@ExperimentalComposePreviewLabApi`-gated
+     * because everything it currently exposes belongs to the still-stabilizing scope
+     * feature. Marking the companion (rather than just the const inside) keeps the
+     * `Companion` class itself out of the BCV baseline — without this marker, the empty
+     * companion class signature stays in `*.api` / `*.klib.api` baselines forever even
+     * after we eventually remove or move `DefaultCollectScope`, locking in the
+     * `Companion` class as ABI surface even though it has no stable members.
+     */
+    @ExperimentalComposePreviewLabApi
     public companion object {
         /**
          * The single source-of-truth string the whole `collectScope` system bottoms out on.
@@ -160,7 +172,6 @@ annotation class ComposePreviewLabOption(
          *    annotating each `@Preview`.
          * 3. If the Gradle DSL was not set either, the runtime default `"default"` applies.
          */
-        @ExperimentalComposePreviewLabApi
         public const val DefaultCollectScope: String = "default"
     }
 }


### PR DESCRIPTION
## Summary

`ComposePreviewLabOption.Companion` object 全体を `@ExperimentalComposePreviewLabApi` で gating
し、 `Companion` class signature を BCV baseline (KLIB) から除外する。 const の lock-in が
将来の `DefaultCollectScope` 削除時に ABI break として現れない構造にする。

## Why

PR #187 で `companion object { @ExperimentalComposePreviewLabApi const val DefaultCollectScope = "default" }` を
追加した結果、 const レベルでは experimental marker で gate されているものの、 **`Companion`
object 自体は baseline に焼き込まれ**、 たとえ const を将来削除しても `Companion` class
declaration は残る (= 空の `Companion` class が ABI surface として永続化する)。

`@ExperimentalComposePreviewLabApi` を companion に移すことで `Companion` 自体が KLIB baseline
filter で除外される (= 探索チケット `#0091` の解消)。

## Changes

| File | 変更内容 |
|------|----------|
| `annotation/.../ComposePreviewLabOption.kt` | `companion object` に `@ExperimentalComposePreviewLabApi` 追加 (KDoc 追記) + 内部 const から redundant な marker を削除 |
| `annotation/api/annotation.klib.api` | `final object Companion` declaration 削除 |
| `annotation/api/jvm/annotation.api`, `annotation/api/android/annotation.api` | `Companion` field と class declaration が削除、 const が outer annotation class の static field として直接現れる (= JVM/Android では `@property:` の既知制約と同形) |

JVM/Android baseline の挙動については root `build.gradle.kts` の Known Limitation block と
PR #187 description の同セクションを参照。 本 PR の主目的 = `Companion` class lock-in の解消は
KLIB / JVM / Android 全 platform で達成。

## Test plan

- [ ] `./gradlew :annotation:compileKotlinJvm` green
- [ ] `./gradlew :core:compileKotlinJvm` green (caller 経路は既に opt-in 済)
- [ ] `./gradlew :compiler-plugin:compileKotlin` green (= compiler-plugin が `DefaultCollectScope` 参照)
- [ ] `./gradlew apiCheck` green
- [ ] caller 全 module で 追加 opt-in 必要箇所が無いこと (既存 `@OptIn(ExperimentalComposePreviewLabApi::class)` でカバー済)

## Refs

- Ticket: `.local/ticket/task-019-companion-abi-strategy.md`
- 探索チケット: `#0091`
- 関連 limitation: `87b81bfd` の build.gradle.kts known limitation comment (= `@property:` JVM/Android asymmetric leak)
- 関連 follow-up: `followup-hint-cross-artifact-and-internal-marker.md` (= ABI 戦略 cluster の別軸)

🤖 Generated with [Claude Code](https://claude.com/claude-code)