### PR TITLE
refactor(compiler-plugin): introduce classIdOf / callableIdOf / buildSimpleAnnotation utils

### DIFF
--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/InternalApiAttachment.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/InternalApiAttachment.kt
@@ -1,6 +1,7 @@
 package me.tbsten.compose.preview.lab.compiler.fir
 
 import me.tbsten.compose.preview.lab.compiler.compat.CompatContext
+import me.tbsten.compose.preview.lab.compiler.utils.classIdOf
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirCallableDeclaration
 import org.jetbrains.kotlin.fir.declarations.FirClassLikeDeclaration
@@ -12,18 +13,10 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.toFirResolvedTypeRef
 import org.jetbrains.kotlin.fir.types.constructType
 import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.name.FqName
-import org.jetbrains.kotlin.name.Name
 
-private val InternalApiClassId = ClassId(
-    FqName("me.tbsten.compose.preview.lab"),
-    Name.identifier("InternalComposePreviewLabApi"),
-)
+private val InternalApiClassId = classIdOf("me.tbsten.compose.preview.lab", "InternalComposePreviewLabApi")
 
-private val SyntheticPreviewHintClassId = ClassId(
-    FqName("me.tbsten.compose.preview.lab"),
-    Name.identifier("SyntheticPreviewHint"),
-)
+private val SyntheticPreviewHintClassId = classIdOf("me.tbsten.compose.preview.lab", "SyntheticPreviewHint")
 
 /**
  * Builds a no-arg FIR annotation for the given `ClassId`.

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/InternalApiAttachment.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/InternalApiAttachment.kt
@@ -2,59 +2,14 @@ package me.tbsten.compose.preview.lab.compiler.fir
 
 import me.tbsten.compose.preview.lab.compiler.compat.CompatContext
 import me.tbsten.compose.preview.lab.compiler.utils.classIdOf
+import me.tbsten.compose.preview.lab.compiler.utils.fir.buildSimpleAnnotation
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirCallableDeclaration
 import org.jetbrains.kotlin.fir.declarations.FirClassLikeDeclaration
-import org.jetbrains.kotlin.fir.expressions.FirAnnotation
-import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotation
-import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotationArgumentMapping
-import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
-import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
-import org.jetbrains.kotlin.fir.toFirResolvedTypeRef
-import org.jetbrains.kotlin.fir.types.constructType
-import org.jetbrains.kotlin.name.ClassId
 
 private val InternalApiClassId = classIdOf("me.tbsten.compose.preview.lab", "InternalComposePreviewLabApi")
 
 private val SyntheticPreviewHintClassId = classIdOf("me.tbsten.compose.preview.lab", "SyntheticPreviewHint")
-
-/**
- * Builds a no-arg FIR annotation for the given `ClassId`.
- *
- * **Sample call**: `buildSimpleAnnotation(session, InternalApiClassId)`
- *
- * **Result** (semantically):
- * ```kotlin
- * @me.tbsten.compose.preview.lab.InternalComposePreviewLabApi
- * ```
- *
- * Both `@InternalComposePreviewLabApi` and `@SyntheticPreviewHint` are no-arg
- * annotations, so an empty `argumentMapping` is sufficient. The annotation type ref
- * is fully resolved so it can be appended to a synthesized declaration's annotation
- * list without further FIR resolution work.
- */
-private fun buildSimpleAnnotation(session: FirSession, classId: ClassId): FirAnnotation = buildAnnotation {
-    // Hard-fail when the annotation symbol can't be resolved: the FIR generator runs only
-    // when the user has applied the Compose Preview Lab Gradle plugin, which always pulls
-    // `:annotation` onto the compilation classpath as a transitive dependency. A null
-    // here therefore signals one of two unrecoverable states — a plugin/runtime version
-    // mismatch (different `:annotation` jar than the plugin expects) or a kctfork test
-    // that does not inline the annotation stub. Both are bugs in the calling environment,
-    // not in user code, so a clear stack trace is preferable to silently falling back
-    // (which would disable `@InternalComposePreviewLabApi` BCV filtering and the
-    // squatting guard simultaneously).
-    val annoSymbol = session.symbolProvider.getClassLikeSymbolByClassId(classId) as? FirRegularClassSymbol
-        ?: error(
-            "$classId annotation symbol is not resolvable from the FIR session. The Compose " +
-                "Preview Lab `:annotation` module must be on the compilation classpath for the " +
-                "per-declaration hint generator. If this fires from a kctfork-style test, ensure " +
-                "the test base inlines the annotation stub for both `@InternalComposePreviewLabApi` " +
-                "and `@SyntheticPreviewHint` (see `CompilerPluginTestBase` / `CompilerPluginJsTestBase`).",
-        )
-
-    annotationTypeRef = annoSymbol.constructType().toFirResolvedTypeRef()
-    argumentMapping = buildAnnotationArgumentMapping {}
-}
 
 /**
  * Attaches `@InternalComposePreviewLabApi` + `@SyntheticPreviewHint` to a synthesized FIR
@@ -86,8 +41,8 @@ private fun buildSimpleAnnotation(session: FirSession, classId: ClassId): FirAnn
 internal fun FirClassLikeDeclaration.markAsInternalSyntheticHint(session: FirSession, compat: CompatContext) {
     replaceAnnotations(
         annotations + listOf(
-            buildSimpleAnnotation(session, InternalApiClassId),
-            buildSimpleAnnotation(session, SyntheticPreviewHintClassId),
+            InternalApiClassId.buildSimpleAnnotation(session),
+            SyntheticPreviewHintClassId.buildSimpleAnnotation(session),
         ),
     )
     compat.getDeprecationsProviderCompat(this, session)?.let(::replaceDeprecationsProvider)
@@ -104,8 +59,8 @@ internal fun FirClassLikeDeclaration.markAsInternalSyntheticHint(session: FirSes
 internal fun FirCallableDeclaration.markAsInternalSyntheticHint(session: FirSession, compat: CompatContext) {
     replaceAnnotations(
         annotations + listOf(
-            buildSimpleAnnotation(session, InternalApiClassId),
-            buildSimpleAnnotation(session, SyntheticPreviewHintClassId),
+            InternalApiClassId.buildSimpleAnnotation(session),
+            SyntheticPreviewHintClassId.buildSimpleAnnotation(session),
         ),
     )
     compat.getDeprecationsProviderCompat(this, session)?.let(::replaceDeprecationsProvider)

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewLabFirBuiltIns.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/fir/PreviewLabFirBuiltIns.kt
@@ -1,6 +1,7 @@
 package me.tbsten.compose.preview.lab.compiler.fir
 
 import me.tbsten.compose.preview.lab.compiler.PluginConfig
+import me.tbsten.compose.preview.lab.compiler.utils.classIdOf
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.extensions.FirExtensionSessionComponent
 import org.jetbrains.kotlin.name.CallableId
@@ -27,10 +28,7 @@ internal class PreviewLabFirBuiltIns(session: FirSession, val config: PluginConf
             FqName.fromSegments(listOf("me", "tbsten", "compose", "preview", "lab", "collectAllModulePreviews"))
 
         /** `me.tbsten.compose.preview.lab.CollectedPreview` `ClassId` — return type of every hint function. */
-        val COLLECTED_PREVIEW_CLASS_ID: ClassId = ClassId(
-            FqName("me.tbsten.compose.preview.lab"),
-            Name.identifier("CollectedPreview"),
-        )
+        val COLLECTED_PREVIEW_CLASS_ID: ClassId = classIdOf("me.tbsten.compose.preview.lab", "CollectedPreview")
 
         /** Package that owns every per-declaration hint function and marker interface. */
         val HINT_PACKAGE: FqName = FqName("me.tbsten.compose.preview.lab.hints")

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/CollectedPreviewIrBuilder.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/CollectedPreviewIrBuilder.kt
@@ -5,6 +5,7 @@ package me.tbsten.compose.preview.lab.compiler.ir
 import me.tbsten.compose.preview.lab.compiler.compat.CompatContext
 import me.tbsten.compose.preview.lab.compiler.compat.IrDeclarationOriginCompat
 import me.tbsten.compose.preview.lab.compiler.compat.addConstructorCallAnnotation
+import me.tbsten.compose.preview.lab.compiler.utils.classIdOf
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
@@ -38,7 +39,7 @@ internal class CollectedPreviewIrBuilder(
 ) {
     val collectedPreviewClass by lazy {
         pluginContext.referenceClass(
-            ClassId(FqName("me.tbsten.compose.preview.lab"), Name.identifier("CollectedPreview")),
+            classIdOf("me.tbsten.compose.preview.lab", "CollectedPreview"),
         )!!
     }
     val collectedPreviewType by lazy { compatContext.getDefaultType(collectedPreviewClass) }

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/CollectedPreviewIrBuilder.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/CollectedPreviewIrBuilder.kt
@@ -25,9 +25,6 @@ import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.makeNullable
 import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
 import org.jetbrains.kotlin.ir.util.constructors
-import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.name.FqName
-import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.SpecialNames
 
 /**
@@ -153,10 +150,7 @@ internal class CollectedPreviewIrBuilder(
     }
 
     private fun addComposableAnnotationIfAvailable(func: IrSimpleFunction) {
-        val composableClassId = ClassId(
-            FqName("androidx.compose.runtime"),
-            Name.identifier("Composable"),
-        )
+        val composableClassId = classIdOf("androidx.compose.runtime", "Composable")
         val composableClass = pluginContext.referenceClass(composableClassId) ?: return
         val ctor = composableClass.constructors.firstOrNull() ?: return
         func.addConstructorCallAnnotation(

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewListIrBuilder.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ir/PreviewListIrBuilder.kt
@@ -5,6 +5,8 @@ package me.tbsten.compose.preview.lab.compiler.ir
 import me.tbsten.compose.preview.lab.compiler.PluginConfig
 import me.tbsten.compose.preview.lab.compiler.compat.CompatContext
 import me.tbsten.compose.preview.lab.compiler.compat.IrDeclarationOriginCompat
+import me.tbsten.compose.preview.lab.compiler.utils.callableIdOf
+import me.tbsten.compose.preview.lab.compiler.utils.classIdOf
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
@@ -25,9 +27,6 @@ import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
 import org.jetbrains.kotlin.ir.util.constructors
-import org.jetbrains.kotlin.name.CallableId
-import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.SpecialNames
 
@@ -75,7 +74,7 @@ internal class PreviewListIrBuilder(
 
     private val sequenceOfCollectedPreviewType by lazy {
         pluginContext.referenceClass(
-            ClassId(FqName("kotlin.sequences"), Name.identifier("Sequence")),
+            classIdOf("kotlin.sequences", "Sequence"),
         )!!.typeWith(collectedPreviewType)
     }
 
@@ -86,7 +85,7 @@ internal class PreviewListIrBuilder(
 
     private val lazyPreviewSequenceFun by lazy {
         pluginContext.referenceFunctions(
-            CallableId(FqName("me.tbsten.compose.preview.lab"), Name.identifier("lazyPreviewSequence")),
+            callableIdOf("me.tbsten.compose.preview.lab", "lazyPreviewSequence"),
         ).firstOrNull() ?: error(
             "me.tbsten.compose.preview.lab.lazyPreviewSequence not found on the compilation classpath. " +
                 "This usually means the compose-preview-lab runtime/core dependency is missing or there is " +
@@ -192,7 +191,7 @@ internal class PreviewListIrBuilder(
 
     private val previewExportClass by lazy {
         pluginContext.referenceClass(
-            ClassId(FqName("me.tbsten.compose.preview.lab"), Name.identifier("PreviewExport")),
+            classIdOf("me.tbsten.compose.preview.lab", "PreviewExport"),
         ) ?: error("PreviewExport class not found on classpath")
     }
 
@@ -240,7 +239,7 @@ internal class PreviewListIrBuilder(
         declarationParent: IrDeclarationParent
     ): IrExpression {
         val lazyFun = pluginContext.referenceFunctions(
-            CallableId(FqName("kotlin"), Name.identifier("lazy")),
+            callableIdOf("kotlin", "lazy"),
         ).first { fn ->
             fn.owner.parameters.filter { it.kind == IrParameterKind.Regular }.size == 1
         }
@@ -273,7 +272,7 @@ internal class PreviewListIrBuilder(
             builder,
             lazyFun,
             pluginContext.referenceClass(
-                ClassId(FqName("kotlin"), Name.identifier("Lazy")),
+                classIdOf("kotlin", "Lazy"),
             )!!.typeWith(sequenceOfCollectedPreviewType),
             listOf(sequenceOfCollectedPreviewType),
         ).apply {
@@ -288,7 +287,7 @@ internal class PreviewListIrBuilder(
      */
     private val distinctPreviewsByIdSequenceFun by lazy {
         pluginContext.referenceFunctions(
-            CallableId(FqName("me.tbsten.compose.preview.lab"), Name.identifier("distinctPreviewsByIdSequence")),
+            callableIdOf("me.tbsten.compose.preview.lab", "distinctPreviewsByIdSequence"),
         ).firstOrNull() ?: error(
             "me.tbsten.compose.preview.lab.distinctPreviewsByIdSequence not found on the compilation classpath. " +
                 "This usually means the compose-preview-lab runtime/core dependency is missing or there is " +

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/utils/CompilerIds.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/utils/CompilerIds.kt
@@ -1,0 +1,32 @@
+package me.tbsten.compose.preview.lab.compiler.utils
+
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+/**
+ * Builds a top-level [ClassId] from a package name and a single class name.
+ *
+ * **Sample call**:
+ * ```kotlin
+ * classIdOf("me.tbsten.compose.preview.lab", "PreviewExport")
+ * // == ClassId(FqName("me.tbsten.compose.preview.lab"), Name.identifier("PreviewExport"))
+ * ```
+ *
+ * Nested classes are out of scope; if a use case appears, add a vararg /
+ * `parent.createNestedClassId(name)` overload at that time.
+ */
+internal fun classIdOf(packageName: String, name: String): ClassId = ClassId(FqName(packageName), Name.identifier(name))
+
+/**
+ * Builds a top-level [CallableId] from a package name and a callable name.
+ *
+ * **Sample call**:
+ * ```kotlin
+ * callableIdOf("kotlin", "lazy")
+ * // == CallableId(FqName("kotlin"), Name.identifier("lazy"))
+ * ```
+ */
+internal fun callableIdOf(packageName: String, name: String): CallableId =
+    CallableId(FqName(packageName), Name.identifier(name))

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/utils/CompilerIds.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/utils/CompilerIds.kt
@@ -27,6 +27,9 @@ internal fun classIdOf(packageName: String, name: String): ClassId = ClassId(FqN
  * callableIdOf("kotlin", "lazy")
  * // == CallableId(FqName("kotlin"), Name.identifier("lazy"))
  * ```
+ *
+ * Class-scoped callables (e.g. `Companion.foo`) are out of scope; if a use case appears,
+ * add an overload that takes a `ClassId` as the parent, or accepts a pre-computed [FqName].
  */
 internal fun callableIdOf(packageName: String, name: String): CallableId =
     CallableId(FqName(packageName), Name.identifier(name))

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/utils/fir/AnnotationBuilders.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/utils/fir/AnnotationBuilders.kt
@@ -15,7 +15,8 @@ import org.jetbrains.kotlin.name.ClassId
  *
  * **Sample call**:
  * ```kotlin
- * val anno = InternalApiClassId.buildSimpleAnnotation(session)
+ * val classId = classIdOf("me.tbsten.compose.preview.lab", "InternalComposePreviewLabApi")
+ * val anno = classId.buildSimpleAnnotation(session)
  * ```
  *
  * **Result** (semantically):
@@ -33,16 +34,19 @@ import org.jetbrains.kotlin.name.ClassId
  * version mismatch, or a kctfork-style test that did not inline the annotation stub),
  * not a user code issue.
  */
-internal fun ClassId.buildSimpleAnnotation(session: FirSession): FirAnnotation = buildAnnotation {
-    val annoSymbol = session.symbolProvider.getClassLikeSymbolByClassId(this@buildSimpleAnnotation) as? FirRegularClassSymbol
-        ?: error(
-            "${this@buildSimpleAnnotation} annotation symbol is not resolvable from the FIR session. The Compose " +
-                "Preview Lab `:annotation` module must be on the compilation classpath for the " +
-                "per-declaration hint generator. If this fires from a kctfork-style test, ensure " +
-                "the test base inlines the annotation stub for both `@InternalComposePreviewLabApi` " +
-                "and `@SyntheticPreviewHint` (see `CompilerPluginTestBase` / `CompilerPluginJsTestBase`).",
-        )
+internal fun ClassId.buildSimpleAnnotation(session: FirSession): FirAnnotation {
+    val classId = this
+    return buildAnnotation {
+        val annoSymbol = session.symbolProvider.getClassLikeSymbolByClassId(classId) as? FirRegularClassSymbol
+            ?: error(
+                "$classId annotation symbol is not resolvable from the FIR session. The Compose " +
+                    "Preview Lab `:annotation` module must be on the compilation classpath for the " +
+                    "per-declaration hint generator. If this fires from a kctfork-style test, ensure " +
+                    "the test base inlines the annotation stub for both `@InternalComposePreviewLabApi` " +
+                    "and `@SyntheticPreviewHint` (see `CompilerPluginTestBase` / `CompilerPluginJsTestBase`).",
+            )
 
-    annotationTypeRef = annoSymbol.constructType().toFirResolvedTypeRef()
-    argumentMapping = buildAnnotationArgumentMapping {}
+        annotationTypeRef = annoSymbol.constructType().toFirResolvedTypeRef()
+        argumentMapping = buildAnnotationArgumentMapping {}
+    }
 }

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/utils/fir/AnnotationBuilders.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/utils/fir/AnnotationBuilders.kt
@@ -1,0 +1,48 @@
+package me.tbsten.compose.preview.lab.compiler.utils.fir
+
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.expressions.FirAnnotation
+import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotation
+import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotationArgumentMapping
+import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
+import org.jetbrains.kotlin.fir.toFirResolvedTypeRef
+import org.jetbrains.kotlin.fir.types.constructType
+import org.jetbrains.kotlin.name.ClassId
+
+/**
+ * Builds a no-arg [FirAnnotation] for this [ClassId].
+ *
+ * **Sample call**:
+ * ```kotlin
+ * val anno = InternalApiClassId.buildSimpleAnnotation(session)
+ * ```
+ *
+ * **Result** (semantically):
+ * ```kotlin
+ * @me.tbsten.compose.preview.lab.InternalComposePreviewLabApi
+ * ```
+ *
+ * The annotation type ref is fully resolved so it can be appended to a synthesized
+ * declaration's annotation list without further FIR resolution work. Annotations
+ * with value arguments are out of scope — add a separate overload when needed.
+ *
+ * If the annotation symbol cannot be resolved from [session], the call fails fast
+ * with a descriptive `IllegalStateException`. A `null` here signals an unrecoverable
+ * environment problem (missing `:annotation` jar on the classpath, plugin/runtime
+ * version mismatch, or a kctfork-style test that did not inline the annotation stub),
+ * not a user code issue.
+ */
+internal fun ClassId.buildSimpleAnnotation(session: FirSession): FirAnnotation = buildAnnotation {
+    val annoSymbol = session.symbolProvider.getClassLikeSymbolByClassId(this@buildSimpleAnnotation) as? FirRegularClassSymbol
+        ?: error(
+            "${this@buildSimpleAnnotation} annotation symbol is not resolvable from the FIR session. The Compose " +
+                "Preview Lab `:annotation` module must be on the compilation classpath for the " +
+                "per-declaration hint generator. If this fires from a kctfork-style test, ensure " +
+                "the test base inlines the annotation stub for both `@InternalComposePreviewLabApi` " +
+                "and `@SyntheticPreviewHint` (see `CompilerPluginTestBase` / `CompilerPluginJsTestBase`).",
+        )
+
+    annotationTypeRef = annoSymbol.constructType().toFirResolvedTypeRef()
+    argumentMapping = buildAnnotationArgumentMapping {}
+}


### PR DESCRIPTION
## Summary

Ticket 5 (compiler API util) — `compiler-plugin/` で頻出する verbose な Kotlin compiler API 構築を、よりエルゴノミックな util / extension で短縮する mechanical refactor。

- `utils/CompilerIds.kt` で `classIdOf` / `callableIdOf` を新設し、`ClassId(FqName(...), Name.identifier(...))` 形式の 11 箇所 (single-line 7 + multi-line 4) を置換
- `utils/fir/AnnotationBuilders.kt` で `ClassId.buildSimpleAnnotation(session)` extension を新設し、 元 `InternalApiAttachment.kt` の `private fun buildSimpleAnnotation(session, classId)` を delete + 4 call site を新形式へ書き換え

すべて semantically equivalent。 値の意味が変わる箇所はゼロ。

## Stacked PR

- **Base**: `feature/compiler-plugin-restructure` (chapter ブランチ、 stacked PR の 1 段目)
- 続く PR は Ticket 0 (error/warning 機構) で、 本 PR を base に作成される

## Scope

### Part 1: `classIdOf` / `callableIdOf` 導入

- `utils/CompilerIds.kt` (new) — `classIdOf(packageName, name): ClassId` + `callableIdOf(packageName, name): CallableId`、 ともに `internal`
- 置換 single-line (7 件):
    - `CollectedPreviewIrBuilder.kt:41` (CollectedPreview ClassId)
    - `PreviewListIrBuilder.kt:78` (Sequence ClassId)
    - `PreviewListIrBuilder.kt:89` (lazyPreviewSequence CallableId)
    - `PreviewListIrBuilder.kt:195` (PreviewExport ClassId)
    - `PreviewListIrBuilder.kt:243` (kotlin.lazy CallableId)
    - `PreviewListIrBuilder.kt:276` (kotlin.Lazy ClassId)
    - `PreviewListIrBuilder.kt:291` (distinctPreviewsByIdSequence CallableId)
- 置換 multi-line (4 件):
    - `CollectedPreviewIrBuilder.kt:155-157` (Composable ClassId)
    - `InternalApiAttachment.kt:18-21` (InternalApiClassId)
    - `InternalApiAttachment.kt:23-26` (SyntheticPreviewHintClassId)
    - `PreviewLabFirBuiltIns.kt:30-32` (COLLECTED_PREVIEW_CLASS_ID)
- 対象外 (HINT_PACKAGE = pre-computed FqName のため `classIdOf(String, String)` で表せず) は **書き換えず温存**:
    - `PreviewHintFirGenerator.kt:188` (single-line, ClassId)
    - `PreviewHintFirGenerator.kt:291-293` (multi-line, ClassId)
    - `PreviewLabFirBuiltIns.kt:51` (CallableId)

### Part 2: `ClassId.buildSimpleAnnotation(session)` extension 化

- `utils/fir/AnnotationBuilders.kt` (new) — `ClassId.buildSimpleAnnotation(session): FirAnnotation`、 元 `InternalApiAttachment.kt` の private 実装をそのまま移植 (failure message も含めて preserve)
- `InternalApiAttachment.kt`:
    - `private fun buildSimpleAnnotation(session, classId)` を delete + 関連 imports 8 件削除
    - 4 call site を `X.buildSimpleAnnotation(session)` 形式に書き換え
    - Sample call KDoc も新形式に更新

## Commit list

| commit | subject |
|---|---|
| `1a7cb8e6` | feat(compiler-plugin/utils): add classIdOf / callableIdOf |
| `f12f424b` | refactor(compiler-plugin): replace single-line ClassId/CallableId(FqName(...)) with classIdOf/callableIdOf |
| `3a9e7930` | refactor(compiler-plugin): collapse multi-line ClassId construction with classIdOf |
| `e81cb23d` | feat(compiler-plugin/utils/fir): add ClassId.buildSimpleAnnotation extension + migrate InternalApiAttachment |

## Diff stat

```
 .../lab/compiler/fir/InternalApiAttachment.kt      | 68 +++-------------------
 .../lab/compiler/fir/PreviewLabFirBuiltIns.kt      |  6 +-
 .../lab/compiler/ir/CollectedPreviewIrBuilder.kt   | 11 +---
 .../lab/compiler/ir/PreviewListIrBuilder.kt        | 17 +++---
 .../preview/lab/compiler/utils/CompilerIds.kt      | 32 ++++++++++
 .../lab/compiler/utils/fir/AnnotationBuilders.kt   | 48 +++++++++++++++
 6 files changed, 101 insertions(+), 81 deletions(-)
```

## Test plan

各 commit 後 + PR 直前の合計 5 ラウンドで 4 項目品質ゲート全 green を確認 (skip なし):

- [x] `./gradlew ktlintFormat ktlintCheck --continue` — EXIT=0 (5/5 回)
- [x] `./gradlew apiCheck --continue` — EXIT=0 (5/5 回、 差分なし)
- [x] `./gradlew :compiler-plugin:test --rerun-tasks --continue` — EXIT=0 (5/5 回)
- [x] `./gradlew jvmTest --rerun-tasks --continue` — EXIT=0 (5/5 回)

追加 sanity check (PR 直前):

- [x] `find compiler-plugin -name "build/api" -type d` → ゼロ (compat-k* のみ生成、 :compiler-plugin 直下なし)
- [x] `git diff -- '*.kt' | grep -E "^\+import .*\.\*$"` → wildcard import 増加ゼロ
- [x] `grep -rnE "ClassId\(.*HINT_PACKAGE\|CallableId\(.*HINT_PACKAGE" compiler-plugin/src/main/kotlin/` → 対象外 3 箇所が温存されている (`PreviewHintFirGenerator.kt:188`, `:291-293`, `PreviewLabFirBuiltIns.kt:51`)
- [x] `grep -rn "ClassId(FqName\|CallableId(FqName" compiler-plugin/src/main/kotlin/` → `utils/CompilerIds.kt` 内部実装/KDoc サンプル以外ゼロ

詳細な探索的検証 (Kotlin version-matrix / integrationTest / dev:runHot / KDoc 規約準拠 / SSoT grep) は Explorer subagent に委ねる。

## 設計逸脱

> **★ 実装時逸脱 (Implementer 起票, 2026-05-11)**: orchestrator 指定の作業ブランチ名 `feature/compiler-plugin-restructure/ticket-5-compiler-api-util` は、 既存ブランチ `feature/compiler-plugin-restructure` (chapter ブランチ) が ref として存在するため、 git の ref namespace ルール (`feature/compiler-plugin-restructure` という file を作った後に同名 directory を作れない) で物理的に作成不可。 代替名 `feature/ticket-5-compiler-api-util` で作業ブランチを切り、 PR base はそのまま `feature/compiler-plugin-restructure` を指す。 ブランチ名のみの変更で、 PR target / stacked chain の構造には影響なし。 ticket file (`.local/ticket/compiler-plugin-restructure-5-compiler-api-ergonomics.md`) にも追記済み。

## Self-Review Log

各 commit 後 + 最終の品質ゲート 4 項目をすべて green で実行。 ログは `.local/tmp/c{1,2,3,4}-{ktlint,jvmTest,compilerPluginTest,apiCheck}.log` と `.local/tmp/final-*.log` に保存済み (exit code は本文 Test plan に記載)。 代表的な BUILD SUCCESSFUL 出力:

```
> Task :compiler-plugin:test
BUILD SUCCESSFUL in 28s
30 actionable tasks: 30 executed
Configuration cache entry reused.
```

```
> Task :dev:jvmTest
BUILD SUCCESSFUL in 16s
109 actionable tasks: 109 executed
Configuration cache entry reused.
```

```
> Task :starter:apiCheck
BUILD SUCCESSFUL in 645ms
543 actionable tasks: 72 executed, 471 up-to-date
Configuration cache entry reused.
```

```
> Task :extension:extension-navigation:ktlintCheck UP-TO-DATE
BUILD SUCCESSFUL in 717ms
331 actionable tasks: 331 up-to-date
Configuration cache entry reused.
```

`:compiler-plugin:test` log 末尾には Kotlin reflection に関する既存 warning が出ているが、 これは PR #187 以前から存在する test ファイルの warning で本 PR とは無関係。 BUILD SUCCESSFUL で test 自体は all-pass。

(全 log は truncate せず保存しているので、 探索的検証 subagent が必要なら参照可能。)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
