### PR TITLE
feat(compiler-plugin/warning): Ticket 4 — structure existing warnings + investigate new candidates

### DIFF
--- a/.claude/rules/compiler-plugin-error.md
+++ b/.claude/rules/compiler-plugin-error.md
@@ -160,7 +160,7 @@ messageCollector.report(
 ### Bad — literal WARNING 直書き
 
 ```kotlin
-// compiler-plugin/.../ir/HintDiscovery.kt
+// compiler-plugin/.../feature/previewCollection/ir/collectPreviewsReplacement/DiscoverHints.kt
 messageCollector.report(
     CompilerMessageSeverity.WARNING,
     "Compose Preview Lab: a function in '${HINT_PACKAGE.asString()}' " +     // ← 構造化なし

--- a/.claude/rules/compiler-plugin-error.md
+++ b/.claude/rules/compiler-plugin-error.md
@@ -51,7 +51,7 @@ Ticket 0 (本 rule 導入時) では、 IR-side WARNING 2 件 + FIR-side defensi
 - `categories: List<Category>` — `IR` / `FIR` / `PREVIEW_COLLECTION` / `INVALID_USAGE` / `VERSION_GATE` / `TRANSFORM_PRIVATE_PREVIEW_TO_INTERNAL` から選ぶ。renderer が `[ComposePreviewLab/<categories>]` prefix として整形する
 - `message: String` — 1 行サマリー (prefix 直後に表示)
 - `description: String?` — 静的な発生条件 / 予防策の散文 (optional)
-- `context: List<ContextEntry>` — `contextOf { +"label"(value) }` DSL で動的値を詰める
+- `context: List<ContextEntry>` — `contextOf { "label"(value) }` DSL で動的値を詰める (`String.invoke(value)` で entry を append。 boolean / tag 用に no-arg `"isHoge"()` overload もあり)
 - `replies: List<String>` — 共通 reply は `error/Replies.kt` の const から取る (`Replies.Unknown` 等)
 
 ## Good / Bad 例
@@ -70,9 +70,9 @@ class HintHashCollisionError(
     override val description: String =
         "Two distinct @Preview functions hash to the same SHA-256 truncated 7-byte value."
     override val context = contextOf {
-        +"hash"(hash)
-        +"preview_a"(previewA)
-        +"preview_b"(previewB)
+        "hash"(hash)
+        "preview_a"(previewA)
+        "preview_b"(previewB)
     }
     override val replies = listOf(Replies.Unknown)
 }
@@ -122,9 +122,9 @@ private val lazyPreviewSequenceFun by lazy {
 
 `Error` と同じ要領で、 `warning/Warnings.kt` に
 `ComposePreviewLabCompilerPluginWarning` 実装 class を追加し、
-`messageCollector.report(warning, location)` extension で呼び出す。 Warning 側の DSL は
-`+"label"(value)` ではなく `"label"(value)` 形式 (label を直接 invoke して entry を
-append する) なので注意。
+`messageCollector.report(warning, location)` extension で呼び出す。 `contextOf { ... }`
+DSL も Error 側と完全に同一 (= `"label"(value)` で entry を append。 boolean / tag は
+no-arg overload `"isHoge"()` で append) で、 `+` prefix は使わない。
 
 ```kotlin
 // compiler-plugin/.../warning/Warnings.kt
@@ -141,7 +141,7 @@ class HintNamespaceSquattingWarning(
         "Only the compose-preview-lab compiler plugin should emit declarations into the " +
             "reserved hint package..."
     override val context = contextOf {
-        "hint_package"(packageName)   // ← warning は + 不要 (label が即 entry を add)
+        "hint_package"(packageName)
         "marker"(markerFqn)
     }
     override val replies = listOf(Replies.InvestigateHintsPackageOwner)

--- a/.claude/rules/compiler-plugin-error.md
+++ b/.claude/rules/compiler-plugin-error.md
@@ -17,14 +17,7 @@ paths:
 
 ## 段階的移行中の既知の rule 違反
 
-Ticket 0 (本 rule 導入時) では、 以下 5 sites を意図的に **未移行のまま** 残している。 後続 ticket での解消を予定。
-
-### Ticket 4 で移行予定 (IR-side WARNING 2 件)
-
-`compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/DiscoverHints.kt:154/175` の
-`messageCollector.report(CompilerMessageSeverity.WARNING, "[ComposePreviewLab] ...")` 直書き 2 件。
-
-これは Ticket 4 で **`warning/Warnings.kt` に対応する Warning 実装を追加 + `messageCollector.report(warning, location)` extension に置換** する予定。 Ticket 0 では warning framework の skeleton (`ComposePreviewLabCompilerPluginWarning` interface + DSL + reporter + placeholder `Warnings` object) のみ用意し、 実 warning 実装は Ticket 4 に委ねた。
+Ticket 0 (本 rule 導入時) では、 IR-side WARNING 2 件 + FIR-side defensive `error()` 3 件の計 5 sites を未移行のまま残していた。 そのうち IR-side WARNING 2 件は **Ticket 4 (A) で構造化済み** (`HintNamespaceSquattingWarning` / `CrossArtifactHintDuplicateWarning` に置換)。 残る 3 件は移行予定なし。
 
 ### Ticket 0 のまま維持 (FIR-side defensive `error()` 3 件)
 
@@ -125,12 +118,81 @@ private val lazyPreviewSequenceFun by lazy {
 }
 ```
 
+### Good — WARNING を構造化
+
+`Error` と同じ要領で、 `warning/Warnings.kt` に
+`ComposePreviewLabCompilerPluginWarning` 実装 class を追加し、
+`messageCollector.report(warning, location)` extension で呼び出す。 Warning 側の DSL は
+`+"label"(value)` ではなく `"label"(value)` 形式 (label を直接 invoke して entry を
+append する) なので注意。
+
+```kotlin
+// compiler-plugin/.../warning/Warnings.kt
+class HintNamespaceSquattingWarning(
+    private val packageName: String,
+    private val markerFqn: String,
+) : ComposePreviewLabCompilerPluginWarning {
+    override val categories = listOf(Category.IR, Category.PREVIEW_COLLECTION)
+    override val message =
+        "a function in '$packageName' matching the per-scope hint shape is missing " +
+            "the @SyntheticPreviewHint marker (marker parameter '$markerFqn') — " +
+            "candidate dropped to prevent namespace squatting"
+    override val description: String =
+        "Only the compose-preview-lab compiler plugin should emit declarations into the " +
+            "reserved hint package..."
+    override val context = contextOf {
+        "hint_package"(packageName)   // ← warning は + 不要 (label が即 entry を add)
+        "marker"(markerFqn)
+    }
+    override val replies = listOf(Replies.InvestigateHintsPackageOwner)
+}
+
+// 呼び出し側
+messageCollector.report(
+    HintNamespaceSquattingWarning(
+        packageName = HINT_PACKAGE.asString(),
+        markerFqn = markerFqn.asString(),
+    ),
+    hintFunction.compilerMessageLocation(),
+)
+```
+
+### Bad — literal WARNING 直書き
+
+```kotlin
+// compiler-plugin/.../ir/HintDiscovery.kt
+messageCollector.report(
+    CompilerMessageSeverity.WARNING,
+    "Compose Preview Lab: a function in '${HINT_PACKAGE.asString()}' " +     // ← 構造化なし
+        "matching the per-scope hint shape is missing the @SyntheticPreviewHint marker " +
+        "(marker parameter '$markerFqn'). ...",
+)                                                                            // ← location も渡せていない
+```
+
 ## 例外: ComposePreviewLabCommandLineProcessor の `CliOptionProcessingException`
 
 `ComposePreviewLabCommandLineProcessor.kt:68` の
 `throw CliOptionProcessingException("Unknown option: $optionName")` は Kotlin compiler API の
 規約に従う defensive ガードで、Kotlin compiler 側のエラーハンドリングと整合させる必要があるため
 **そのまま維持** する。Error 実装でラップしない。
+
+## 新規 Warning を追加する時の手順
+
+(Ticket 4 後の運用想定)
+
+1. **判断**: 「処理を止める必要があるか」を最初に判断。 止める = `error/Errors.kt` (ERROR)、 止めない = `warning/Warnings.kt` (WARNING)。 境界が曖昧なものは Error 側に倒すか `@ComposePreviewLabOption` で opt-in に逃がす
+2. **false positive 検証**: 「ユーザーが意図的にそうしている可能性が高い」 入力にまで warning を出さないかを 3 軸で評価:
+   - ユーザーが知りたい状況か
+   - 処理を止めるほどではないか
+   - false positive にならないか
+3. **Kotlin 標準の警告との重複回避**: Kotlin compiler が出す deprecated / unused / unchecked cast 等の警告と重複しない、 本 plugin 固有の知識でしか出せないものに限定
+4. **`warning/Warnings.kt` に Warning class 追加**:
+   - constructor parameter として動的値を受け取る
+   - `categories: List<Category>` で `IR` / `FIR` + feature 軸 (`PREVIEW_COLLECTION` 等) を選ぶ
+   - `message` / `description` / `context` (= `contextOf { "label"(value) }`) / `replies` を `override`
+   - 共通 reply は `error/Replies.kt` (= `ComposePreviewLabCompilerPluginError.Replies` の typealias) の const から取る。 新規 reply を追加する場合は `Replies` object に const として追加し、 wording を 1 箇所で管理
+5. **呼び出し側**: `messageCollector.report(SomeWarning(args), location)` extension で呼ぶ。 `location` は `IrDeclaration.compilerMessageLocation()` (= `utils/ir/CompilerMessageLocation.kt`) で取得すると IDE 連携が効く
+6. **テスト**: 「warning が出る入力」 と 「warning が出ない正常入力」 の 両方を kctfork 経由で 検証 (false positive guard)
 
 ## チェックリスト (PR レビュー時)
 
@@ -141,3 +203,4 @@ private val lazyPreviewSequenceFun by lazy {
 - [ ] `categories` の選択が妥当 (`IR` / `FIR` + feature 軸 + 必要なら `INVALID_USAGE` / `VERSION_GATE`)
 - [ ] 共通 reply は `error/Replies.kt` の const から取る (Bug-report `Replies.Unknown` / version upgrade `Replies.UpgradeKotlin2321` 等)
 - [ ] FIR 側 `KtDiagnosticFactory` (= `CollectScopeErrors.kt`) は対象外として明示的に許容
+- [ ] 新規 Warning は false positive リスクを 3 軸で評価済み (「ユーザーが知りたい状況か」「処理を止めるほどでないか」「false positive にならないか」)

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/error/ComposePreviewLabCompilerPluginError.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/error/ComposePreviewLabCompilerPluginError.kt
@@ -206,5 +206,58 @@ interface ComposePreviewLabCompilerPluginError {
 
               val previews by collectModulePreviews(scope = "acme_ui")
             """.trimIndent()
+
+        /**
+         * Reply for `HintNamespaceSquattingWarning` — a third-party declaration inside
+         * `me.tbsten.compose.preview.lab.hints` matched the per-scope hint shape but did
+         * not carry the plugin-stamped `@SyntheticPreviewHint` marker. The candidate is
+         * dropped from the aggregated preview list to defend against namespace squatting.
+         *
+         * The reply walks users through the two most likely root causes (an unrelated
+         * library happened to declare into the reserved package, or a hand-rolled
+         * declaration accidentally landed in the hints package) and tells them they can
+         * safely ignore the warning when the candidate is intentional but not authored by
+         * the plugin.
+         */
+        val InvestigateHintsPackageOwner: String =
+            """
+            The `me.tbsten.compose.preview.lab.hints` package is reserved for declarations
+            emitted by the compose-preview-lab compiler plugin — every authentic hint is
+            marked with `@me.tbsten.compose.preview.lab.SyntheticPreviewHint`. A function in
+            the package without that marker either:
+
+              - originates from a third-party artifact that happens to declare into the
+                reserved package (likely a name collision with another preview library), or
+              - was added by hand to the consuming module (move it out of the reserved
+                package — top-level declarations elsewhere work fine).
+
+            If the candidate is intentional but not produced by the plugin, you can safely
+            ignore this warning; the candidate is dropped from the aggregated preview list
+            so the runtime behaviour is unchanged.
+            """.trimIndent()
+
+        /**
+         * Reply for `CrossArtifactHintDuplicateWarning` — `referenceFunctions` returned
+         * two or more hint stubs sharing the same marker FQN, meaning the same `@Preview`
+         * source is pulled in through more than one artifact coordinate. Runtime
+         * `distinctPreviewsById` already collapses the duplicates, so processing
+         * continues; the warning surfaces a likely dependency-graph misconfiguration.
+         */
+        val InvestigateDuplicateArtifacts: String =
+            """
+            Runtime `distinctPreviewsById` keeps the first occurrence so the user-visible
+            list stays correct, but the duplicated artifacts likely indicate one of:
+
+              - the same source module is published under two coordinates (e.g. a renamed
+                artifact still shipping alongside the original),
+              - a transitive dependency pulls in the same library at two different
+                versions, or
+              - an incremental-compile partial state surfaces both the cached and the
+                rebuilt symbol (rare; usually clears on a clean rebuild).
+
+            Inspect the resolved dependency graph (`./gradlew dependencies` /
+            `./gradlew :app:dependencies`) for duplicate paths to the artifact that owns
+            the marker FQN, or run a clean rebuild if you suspect IC state.
+            """.trimIndent()
     }
 }

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/DiscoverHints.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/DiscoverHints.kt
@@ -10,9 +10,12 @@ import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.hintFunc
 
 import me.tbsten.compose.preview.lab.compiler.compat.CompatContext
 import me.tbsten.compose.preview.lab.compiler.compat.IrDeclarationOriginCompat
+import me.tbsten.compose.preview.lab.compiler.utils.ir.compilerMessageLocation
 import me.tbsten.compose.preview.lab.compiler.utils.ir.requiresKlibIcSafetyForCrossModuleHint
+import me.tbsten.compose.preview.lab.compiler.warning.CrossArtifactHintDuplicateWarning
+import me.tbsten.compose.preview.lab.compiler.warning.HintNamespaceSquattingWarning
+import me.tbsten.compose.preview.lab.compiler.warning.report
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
@@ -151,12 +154,11 @@ internal fun discoverHints(
             true
         } else {
             messageCollector.report(
-                CompilerMessageSeverity.WARNING,
-                "Compose Preview Lab: a function in '${HINT_PACKAGE.asString()}' " +
-                    "matching the per-scope hint shape is missing the @SyntheticPreviewHint marker " +
-                    "(marker parameter '$markerFqn'). Only the Compose Preview Lab compiler plugin " +
-                    "should emit declarations into this package; the candidate will be ignored to " +
-                    "prevent namespace squatting.",
+                HintNamespaceSquattingWarning(
+                    packageName = HINT_PACKAGE.asString(),
+                    markerFqn = markerFqn.asString(),
+                ),
+                hintFunction.compilerMessageLocation(),
             )
             false
         }
@@ -172,12 +174,12 @@ internal fun discoverHints(
         .filterValues { it.size > 1 }
         .forEach { (markerFqn, duplicates) ->
             messageCollector.report(
-                CompilerMessageSeverity.WARNING,
-                "Compose Preview Lab: ${duplicates.size} synthetic hint functions on the classpath " +
-                    "share marker '$markerFqn' (scope = '$scope'). The same `@Preview` is included via " +
-                    "multiple artifacts; runtime `distinctPreviewsById` retains the first occurrence " +
-                    "only. Verify the dependency tree if you did not intend to publish the same " +
-                    "preview source from two coordinates.",
+                CrossArtifactHintDuplicateWarning(
+                    count = duplicates.size,
+                    markerFqn = markerFqn.asString(),
+                    scope = scope,
+                ),
+                duplicates.first().first.compilerMessageLocation(),
             )
         }
 

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/buildPreviewSequence/BuildLazyWrapperIr.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/buildPreviewSequence/BuildLazyWrapperIr.kt
@@ -3,6 +3,8 @@
 package me.tbsten.compose.preview.lab.compiler.feature.previewCollection.ir.collectPreviewsReplacement.buildPreviewSequence
 
 import me.tbsten.compose.preview.lab.compiler.compat.IrDeclarationOriginCompat
+import me.tbsten.compose.preview.lab.compiler.error.StdlibClassNotFoundError
+import me.tbsten.compose.preview.lab.compiler.error.orThrow
 import me.tbsten.compose.preview.lab.compiler.utils.callableIdOf
 import me.tbsten.compose.preview.lab.compiler.utils.classIdOf
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
@@ -77,12 +79,15 @@ internal class BuildLazyWrapperIr(private val context: PreviewSequenceBuildConte
             function = lambdaFun,
         )
 
+        val lazyType = context.pluginContext.referenceClass(
+            classIdOf("kotlin", "Lazy"),
+        ).orThrow { StdlibClassNotFoundError("kotlin.Lazy") }
+            .typeWith(context.sequenceOfCollectedPreviewType)
+
         return context.compatContext.irCall(
             builder,
             lazyFun,
-            context.pluginContext.referenceClass(
-                classIdOf("kotlin", "Lazy"),
-            )!!.typeWith(context.sequenceOfCollectedPreviewType),
+            lazyType,
             listOf(context.sequenceOfCollectedPreviewType),
         ).apply {
             arguments[0] = lambdaExpr

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/buildPreviewSequence/BuildPreviewSequenceIr.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/buildPreviewSequence/BuildPreviewSequenceIr.kt
@@ -5,6 +5,8 @@ package me.tbsten.compose.preview.lab.compiler.feature.previewCollection.ir.coll
 import me.tbsten.compose.preview.lab.compiler.compat.CompatContext
 import me.tbsten.compose.preview.lab.compiler.compat.IrDeclarationOriginCompat
 import me.tbsten.compose.preview.lab.compiler.error.RuntimeFunctionNotFoundError
+import me.tbsten.compose.preview.lab.compiler.error.StdlibClassNotFoundError
+import me.tbsten.compose.preview.lab.compiler.error.orThrow
 import me.tbsten.compose.preview.lab.compiler.error.throwAsException
 import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.PreviewFunctionInfo
 import me.tbsten.compose.preview.lab.compiler.utils.callableIdOf
@@ -96,7 +98,8 @@ internal class PreviewSequenceBuildContext(val pluginContext: IrPluginContext, v
     val sequenceOfCollectedPreviewType: IrType by lazy {
         pluginContext.referenceClass(
             classIdOf("kotlin.sequences", "Sequence"),
-        )!!.typeWith(collectedPreviewType)
+        ).orThrow { StdlibClassNotFoundError("kotlin.sequences.Sequence") }
+            .typeWith(collectedPreviewType)
     }
 
     /** `() -> CollectedPreview` factory-lambda type used for the `lazyPreviewSequence` vararg. */

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/warning/Warnings.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/warning/Warnings.kt
@@ -47,7 +47,7 @@ import me.tbsten.compose.preview.lab.compiler.error.Replies
  *     marker: me.tbsten.compose.preview.lab.hints.PreviewHintMarker_squatter_Fake_deadbeef
  * ```
  */
-class HintNamespaceSquattingWarning(private val packageName: String, private val markerFqn: String,) :
+class HintNamespaceSquattingWarning(private val packageName: String, private val markerFqn: String) :
     ComposePreviewLabCompilerPluginWarning {
     override val categories: List<Category> = listOf(Category.IR, Category.PREVIEW_COLLECTION)
     override val message: String =
@@ -99,8 +99,16 @@ class HintNamespaceSquattingWarning(private val packageName: String, private val
  *     scope: default
  * ```
  */
-class CrossArtifactHintDuplicateWarning(private val count: Int, private val markerFqn: String, private val scope: String,) :
+class CrossArtifactHintDuplicateWarning(private val count: Int, private val markerFqn: String, private val scope: String) :
     ComposePreviewLabCompilerPluginWarning {
+    init {
+        // Invariant: this warning only fires after `.filterValues { it.size > 1 }`
+        // in DiscoverHints.kt, so callers must pass at least 2. Guarding here keeps
+        // the wording "$count synthetic hint functions ... share marker" honest
+        // (singular "1" would be a misleading regression).
+        require(count >= 2) { "count must be >= 2 (got $count)" }
+    }
+
     override val categories: List<Category> = listOf(Category.IR, Category.PREVIEW_COLLECTION)
     override val message: String =
         "$count synthetic hint functions on the classpath share marker '$markerFqn' (scope = '$scope') — " +

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/warning/Warnings.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/warning/Warnings.kt
@@ -1,16 +1,119 @@
 package me.tbsten.compose.preview.lab.compiler.warning
 
+import me.tbsten.compose.preview.lab.compiler.error.ComposePreviewLabCompilerPluginError.Category
+import me.tbsten.compose.preview.lab.compiler.error.Replies
+
+// Concrete `ComposePreviewLabCompilerPluginWarning` implementations for the IR-side
+// warning sites enumerated in
+// `.local/ticket/compiler-plugin-restructure-4-warning-expansion.md`.
+//
+// Each implementation takes the dynamic values it needs as constructor parameters,
+// surfaces them through `context = contextOf { ... }`, and points at a `Replies.*`
+// snippet for the "How to reply:" section. The reply constants are reused from the
+// shared `error/Replies.kt` (re-exported via the top-level `Replies` typealias) so
+// wording stays consistent across error / warning surfaces.
+
+// -----------------------------------------------------------------------------
+// IR WARNING — discoverHints: namespace squatting / cross-artifact duplicates
+// -----------------------------------------------------------------------------
+
 /**
- * Placeholder home for concrete [ComposePreviewLabCompilerPluginWarning] implementations.
+ * `[ComposePreviewLab/IR,PREVIEW_COLLECTION] a function in
+ * 'me.tbsten.compose.preview.lab.hints' matching the per-scope hint shape is missing
+ * the @SyntheticPreviewHint marker`. Fires from `discoverHints` (IR pass) when a
+ * candidate has the right structural shape (correct package, marker-shape parameter,
+ * `CollectedPreview` return type, name pattern) but lacks the plugin-stamped
+ * `@SyntheticPreviewHint` annotation.
  *
- * Ticket 0 only ships the warning skeleton (interface + DSL + reporter). The two
- * existing warning sites in
- * `feature/previewCollection/ir/collectPreviewsReplacement/DiscoverHints.kt` (the
- * squatting guard near line 154 and the cross-artifact dup detection near line 174)
- * are migrated in Ticket 4 along with any new warning classes introduced by the
- * warning-expansion plan.
+ * The candidate is filtered out of the aggregated preview list to prevent a
+ * third-party library from squatting the reserved `me.tbsten.compose.preview.lab.hints`
+ * package and injecting previews into the consumer's `collectAllModulePreviews()`
+ * result. Processing continues with the remaining authentic hints — the warning
+ * surfaces the dropped candidate so users can investigate the dependency that owns it.
  *
- * The empty object keeps the file layout symmetric to `error/Errors.kt` so future
- * warnings have an obvious place to land.
+ * **Sample rendered output**:
+ * ```
+ * [ComposePreviewLab/IR,PREVIEW_COLLECTION] a function in
+ * 'me.tbsten.compose.preview.lab.hints' matching the per-scope hint shape is missing
+ * the @SyntheticPreviewHint marker — candidate dropped to prevent namespace squatting
+ *
+ *     Only the compose-preview-lab compiler plugin should emit declarations into the
+ *     reserved hint package. A function in this package that lacks the
+ *     `@me.tbsten.compose.preview.lab.SyntheticPreviewHint` marker is treated as a
+ *     squatter and dropped from the aggregated preview list. ...
+ *
+ *   Context:
+ *     hint_package: me.tbsten.compose.preview.lab.hints
+ *     marker: me.tbsten.compose.preview.lab.hints.PreviewHintMarker_squatter_Fake_deadbeef
+ * ```
  */
-internal object Warnings
+class HintNamespaceSquattingWarning(private val packageName: String, private val markerFqn: String,) :
+    ComposePreviewLabCompilerPluginWarning {
+    override val categories: List<Category> = listOf(Category.IR, Category.PREVIEW_COLLECTION)
+    override val message: String =
+        "a function in '$packageName' matching the per-scope hint shape is missing the @SyntheticPreviewHint marker " +
+            "(marker parameter '$markerFqn') — candidate dropped to prevent namespace squatting"
+    override val description: String =
+        "Only the compose-preview-lab compiler plugin should emit declarations into the reserved hint package. " +
+            "A function in this package that lacks the `@me.tbsten.compose.preview.lab.SyntheticPreviewHint` " +
+            "marker is treated as a squatter and dropped from the aggregated preview list — the structural " +
+            "shape alone (correct package, marker-shape parameter, `CollectedPreview` return type, name " +
+            "pattern) is not enough to be considered authentic."
+    override val context: List<String> = contextOf {
+        "hint_package"(packageName)
+        "marker"(markerFqn)
+    }
+    override val replies: List<String> = listOf(Replies.InvestigateHintsPackageOwner)
+}
+
+/**
+ * `[ComposePreviewLab/IR,PREVIEW_COLLECTION] N synthetic hint functions on the
+ * classpath share marker '<fqn>' (scope = '<scope>')`. Fires from `discoverHints`
+ * (IR pass) when `referenceFunctions(previewHint_<scope>)` returns two or more
+ * authentic hints (passed the `@SyntheticPreviewHint` squatting guard) sharing the
+ * same marker FQN — i.e. the same source `@Preview` signature is reachable through
+ * multiple dependency-graph paths.
+ *
+ * Runtime `distinctPreviewsById` already collapses the duplicates, so processing
+ * continues; the warning surfaces a likely dependency-graph misconfiguration (e.g.
+ * the same library republished under two coordinates, two versions on the classpath,
+ * or an incremental-compile partial state surfacing both the cached and the rebuilt
+ * symbol).
+ *
+ * Note: in practice this is hard to trigger end-to-end because both the JVM
+ * classloader and the KLIB linker collapse same-FQN duplicates down to a single
+ * symbol before `referenceFunctions` returns. The warning is kept for unusual setups
+ * where the symbol provider surfaces both declarations and to make the intent
+ * explicit; the runtime `distinctPreviewsById` is the user-visible signal in the
+ * common case.
+ *
+ * **Sample rendered output**:
+ * ```
+ * [ComposePreviewLab/IR,PREVIEW_COLLECTION] 2 synthetic hint functions on the
+ * classpath share marker 'me.tbsten.compose.preview.lab.hints.PreviewHintMarker_uilib_default_MyButton_abcd123'
+ * (scope = 'default') — runtime distinctPreviewsById will keep the first occurrence
+ *
+ *   Context:
+ *     count: 2
+ *     marker: me.tbsten.compose.preview.lab.hints.PreviewHintMarker_uilib_default_MyButton_abcd123
+ *     scope: default
+ * ```
+ */
+class CrossArtifactHintDuplicateWarning(private val count: Int, private val markerFqn: String, private val scope: String,) :
+    ComposePreviewLabCompilerPluginWarning {
+    override val categories: List<Category> = listOf(Category.IR, Category.PREVIEW_COLLECTION)
+    override val message: String =
+        "$count synthetic hint functions on the classpath share marker '$markerFqn' (scope = '$scope') — " +
+            "runtime `distinctPreviewsById` will keep the first occurrence"
+    override val description: String =
+        "The same `@Preview` source is reachable through multiple dependency-graph paths, so the per-scope " +
+            "hint stub is provided by two or more artifacts simultaneously. Runtime " +
+            "`distinctPreviewsById` retains only the first occurrence, but the over-pull usually points at " +
+            "a dependency-graph misconfiguration worth investigating."
+    override val context: List<String> = contextOf {
+        "count"(count.toString())
+        "marker"(markerFqn)
+        "scope"(scope)
+    }
+    override val replies: List<String> = listOf(Replies.InvestigateDuplicateArtifacts)
+}


### PR DESCRIPTION
## 概要

Ticket 4 「warning 出力箇所の見直し・拡充」 を実装。 `.local/ticket/compiler-plugin-restructure-4-warning-expansion.md` の (A) + (B) を扱う。

- **(A) 既存 literal warning の構造化** (確定済み 2 件)
  `DiscoverHints.kt` (旧 `ir/HintDiscovery.kt`) の squatting guard + cross-artifact dup の 2 件 literal WARNING を、 PR #199 で導入された `ComposePreviewLabCompilerPluginWarning` interface 経由の構造化 warning に置換。
- **(B) 新規 warning 候補の調査**
  silent drop / defensive `error()` / 境界条件 / no-op 組み合わせを機械的に列挙 (11 件) し、 3 軸 (「ユーザーが知りたい状況か」 「処理を止めるほどでないか」 「false positive にならないか」) で評価。 確信度高の候補は 0 件のため、 本 PR では (A) の 2 件構造化のみが機能変更。 詳細は `.local/tmp/warning-candidates.md` (gitignore 対象、 PR には含まれない)。

## 変更内容

### (A) — `feat(compiler-plugin/warning): structure existing literal warnings`

| ファイル | 変更 |
| --- | --- |
| `warning/Warnings.kt` | `HintNamespaceSquattingWarning(packageName, markerFqn)` / `CrossArtifactHintDuplicateWarning(count, markerFqn, scope)` 追加 (categories: `IR`, `PREVIEW_COLLECTION`)。 |
| `error/ComposePreviewLabCompilerPluginError.kt` | `Replies.InvestigateHintsPackageOwner` / `Replies.InvestigateDuplicateArtifacts` 追加。 |
| `feature/.../DiscoverHints.kt` | 2 箇所の `messageCollector.report(CompilerMessageSeverity.WARNING, \"[ComposePreviewLab] ...\", ...)` literal を `messageCollector.report(SomeWarning(...), hintFunction.compilerMessageLocation())` に置換。 `location` を渡すことで以前は sourceless だった warning が IDE 上の該当 hint stub に紐づく。 |

### Docs — `docs(rules): update compiler-plugin-error with WARNING examples`

| ファイル | 変更 |
| --- | --- |
| `.claude/rules/compiler-plugin-error.md` | 「Ticket 4 で移行予定 (IR-side WARNING 2 件)」 carve-out 削除 (FIR-side defensive `error()` 3 件のみ残る)。 「Good — WARNING を構造化」 / 「Bad — literal WARNING 直書き」 例を追加。 「新規 Warning を追加する時の手順」 セクションを追加 (false positive 3 軸チェック、 Kotlin 標準警告との重複回避、 reply snippet centralisation 等)。 チェックリストに false positive 3 軸 bullet を追加。 |

## (B) 調査結果サマリー

`.local/tmp/warning-candidates.md` に 11 件 (B-1 〜 B-11) を整理。 全件 「採用見送り」。

| 不採用カテゴリ | 該当候補 | 理由 |
| --- | --- | --- |
| Error と二重 gate | B-1, B-2 | caller で既に `UnsupportedCollectAllError` を出すため、 silent drop site で warning を追加すると error/warning の二重出力でユーザを混乱させる |
| false positive リスク許容できず | B-3 (大規模 monorepo で常時 noise), B-4 (`ignore=true` を non-`@Preview` に付ける = IDE Checker が筋), B-8 (`ExtractedSourceText` PSI 不在は kctfork で頻発) | |
| 内部 invariant 違反 = error 化が筋 | B-7, B-9, B-10 | warning では弱すぎる。 別 ticket 起票候補としてメモ |
| 正常 path | B-5, B-6 | warning する性質のものではない |
| 現状不要 | B-11 (deprecated 経路) | 該当 API がない |

`ticket-4-warning-expansion.md` の 「調査結果が『特に warning すべき箇所がない』結論でも OK」 に従い、 (B) は 0 件で close。

## 品質ゲート (全 green)

- `./gradlew :compiler-plugin:ktlintFormat` — auto-fix 後 trailing comma 1 件 (既存スタイルと整合)
- `./gradlew ktlintCheck --continue` — pass
- `./gradlew apiCheck --continue` — pass (public API 不変)
- `./gradlew :compiler-plugin:test --rerun-tasks --continue` — pass (`HintCrossArtifactAndSquattingTest` 2/2 含む)

## Test 影響

- `HintCrossArtifactAndSquattingTest` の assertion は substring 一致 (`shouldContain "missing the @SyntheticPreviewHint marker"` / `"PreviewHintMarker_squatter_Fake_deadbeef"` / `"share marker"`) のため、 新 message が同じ substring を保持しているので追従更新不要。 既存 test がそのまま pass し、 false positive guard (`baseline: a plain dep without squatters does not trigger any namespace-squatting warning`) も pass。

## 留意点

- (A) の `DiscoverHints.kt` KDoc 内 (line 122-127) の `@Suppress("DEPRECATION")` ブロックの comment は 「the two warnings we emit here」 のままで正しい (warning は依然 2 種類、 構造化されただけ)。
- 候補 B-9 (`BuildCollectedPreviewIr.kt:173-174` の `composableClass not found` silent drop) と B-10 (`FillPreviewHintIrBody.kt:96,100` の defensive return) は **error 化が筋** という結論で、 別 ticket 起票候補としてメモ。

## Base

`feature/ticket-1-restructure` (stacked PR)

## Ticket

`.local/ticket/compiler-plugin-restructure-4-warning-expansion.md`

<details>
<summary>Self-Review Log</summary>

### Self-review チェック

- [x] 必読 3 件 (README.md / errors.md / implementation-reference.md) + ticket 4 + `.claude/rules/compiler-plugin-error.md` 全読了
- [x] `DiscoverHints.kt` 旧 path が PR #200 後に `feature/.../collectPreviewsReplacement/DiscoverHints.kt` に move 済みであることを確認 (`find compiler-plugin -name DiscoverHints.kt`)
- [x] (A) は `messageCollector.report(warning, location)` extension (PR #199 で導入済み) を使用、 `location` も `hintFunction.compilerMessageLocation()` で適切に渡している
- [x] (A) Warning class 2 つは `IR` + `PREVIEW_COLLECTION` category と既存 IR error の category 整合
- [x] (A) Replies は `Replies` typealias から `Replies.InvestigateHintsPackageOwner` / `Replies.InvestigateDuplicateArtifacts` で参照 (wording 一元管理)
- [x] (A) message 文言は既存 substring assertion (`"missing the @SyntheticPreviewHint marker"` / `"PreviewHintMarker_squatter_Fake_deadbeef"` / `"share marker"`) を保持
- [x] (B) 候補列挙の grep を `compiler-plugin/src/main/kotlin/` 配下で 48 件確認、 11 件に集約し 3 軸評価
- [x] (B) 各候補の不採用理由を `false positive リスク` / `error 化が筋` / `内部 invariant` / `正常 path` のカテゴリで明示
- [x] (B) 別 ticket 起票候補 (B-9, B-10) を memo として `.local/tmp/warning-candidates.md` に残した
- [x] rule update から Ticket 4 carve-out を削除、 残 FIR-side defensive `error()` 3 件 のみ documented exemption
- [x] rule update に Warning 用 Good/Bad 例 + 「新規 Warning を追加する時の手順」 + チェックリスト bullet 追加
- [x] DSL の差異 (error: `+"label"(value)`, warning: `"label"(value)`) を rule 内で明示
- [x] `.local/` は gitignore 対象 (`git check-ignore .local/tmp/warning-candidates.md` で確認)
- [x] 品質ゲート全 green (ktlintCheck / apiCheck / compiler-plugin test)
- [x] commit 単位はレビューしやすい意味ある粒度 (1: (A) 構造化, 2: docs rule update)。 (B) の 0 件結論は commit 1 + 2 のどちらにも統合 (新規 commit 不要)
- [x] PR base = `feature/ticket-1-restructure` (stacked)
- [x] destructive operations 不使用、 `gh pr merge` 未実行、 他 subagent kick なし

### 候補絞り込み判断の根拠

- B-1, B-2 (Kotlin version 境界): caller (`ReplaceCollectPreviewsFunBody.kt:188-203`) で `UnsupportedCollectAllError` を error 出力済み。 同 logic 上で error と warning を併発するとユーザは指示の優先度を判断できない → 不採用
- B-3 (性能リスク n>1000): SHA-256 7-byte truncate の collision probability ~10⁻⁷ at 1k previews という設計前提があり、 「閾値 N で予防警告」 は理論上 false positive (実 collision が起きていない正常状態) → 不採用
- B-4 (`ignore=true` no-op): FIR Checker (= scope validation の checker と同類) で対応するのが適切な位置。 IR phase で warning を出すと utility 関数等の legitimate な ignore も鳴る → 不採用
- B-9, B-10 (内部 invariant): warning では弱すぎる。 silent でも runtime NPE / 機能 broken に直結 → error 化が筋。 ただし error 化は本 ticket scope 外で、 false positive 再現 (kctfork) も別途必要 → 別 ticket 起票候補
- B-11 (deprecated 経路): 現状 deprecated 予定 API なし。 枠組みだけ用意するのは over-engineering → 不採用

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Rebase Log

### 2026-05-11 — rebase onto PR #200 (ticket-1) Explorer-C follow-up 5 commits

PR #200 (`feature/ticket-1-restructure`) に Explorer-C 残指摘対応で 5 commits (`b02158dd` 〜 `1c81d67b`: dead helper / SSoT 集約 / dead constructor params 削除 / 古い KDoc reference 更新) が追加されたため、 PR #202 の base が変動し `mergeStateStatus: DIRTY` (conflict) になった。

**rebase 操作**: `git rebase origin/feature/ticket-1-restructure` を実行。 conflict 2 件解消後 `git push --force-with-lease`。

**取り込んだ commit (PR #200 由来 5 件)**:

- `1c81d67b refactor(compiler-plugin): remove dead constructor params + invoke arg`
- `8e1a17e1 docs(compiler-plugin): update stale KDoc/comment references to current class names`
- `e85db156 refactor(compiler-plugin): consolidate annotation FQN/ClassId SSoT`
- `5c5ea51f refactor(compiler-plugin): consolidate CollectScopes/Ignore parameter (...)`
- `b02158dd refactor(compiler-plugin): remove dead isHintFunctionName helper`

**conflict 2 件の解消内容**:

1. `compiler-plugin/.../warning/Warnings.kt` — `HintNamespaceSquattingWarning` の KDoc 内で、 PR #200 は 「Ticket 0 only ships the warning skeleton ... migrated in Ticket 4」 という Ticket 0 時点の状態説明、 PR #202 は 「The candidate is filtered out ... to prevent ... namespace squatting」 という構造化済み warning の動作説明。 PR #202 (Ticket 4) で既に warning 実装が actual に動作する状態なので、 動作説明の側 (PR #202) を採用するのが semantically 正しい。
2. `.claude/rules/compiler-plugin-error.md` — 「段階的移行中の既知の rule 違反」 セクションで、 PR #200 は 「Ticket 4 で移行予定」 sub-section を残した 5 sites carve-out、 PR #202 は 「Ticket 4 (A) で構造化済み」 と更新し残 3 sites carve-out に縮小。 PR #202 が Ticket 4 (A) を実施しているので、 縮小済みテキスト (PR #202) を採用するのが事実と整合。

**rebase 後の 4 項目品質ゲート (全 green)**:

- `./gradlew ktlintFormat ktlintCheck --continue` — exit=0 (auto-fix 差分なし)
- `./gradlew apiCheck --continue` — exit=0 (public API 不変)
- `./gradlew jvmTest --rerun-tasks --continue` — exit=0
- `./gradlew :compiler-plugin:test --rerun-tasks --continue` — exit=0 (`HintCrossArtifactAndSquattingTest` 含む)

## 2026-05-11 — Explorer-C iter regression fix + docs drift + NIT cleanup (3 commits)

PR #202 Explorer-C 検証で 要修正 1 件 + 要議論 1 件 + NIT 2 件 を投稿。 本 iter で全て対応。

**3 commits 追加**:

- `e48e1202 fix(compiler-plugin): restore StdlibClassNotFoundError for Sequence/Lazy referenceClass`
  - 要修正対応。 commit `291e2e98` の split で regress していた 2 sites を、 `f2af2c78` の fix と同じ pattern で復元 (`!!` → `.orThrow { StdlibClassNotFoundError(...) }`)
  - `BuildPreviewSequenceIr.kt:97-100` (`kotlin.sequences.Sequence`)
  - `BuildLazyWrapperIr.kt:82-85` (`kotlin.Lazy`)
- `588a2d15 docs(rules): fix contextOf DSL example to match actual syntax`
  - 要議論対応 (本 PR で対応推奨)。 `.claude/rules/compiler-plugin-error.md` の Good ERROR example が `+"label"(value)` (= 存在しない `unaryPlus` operator) を示してコピペで compile fail する状態だったため、 実装 (= `String.invoke(value)` only) に整合させた
  - WARNING section の「Warning は + 不要」 という ERROR との 差分強調も、 ERROR / WARNING 両方とも同じ DSL である事実を反映して書き直し
- `79ac7bc6 style(compiler-plugin/warning): align Warnings.kt single-line constructors with Errors.kt`
  - NIT 1 + NIT 2 対応。 `Warnings.kt:50, 102` の trailing comma を `Errors.kt` 慣例に合わせて削除 + `CrossArtifactHintDuplicateWarning.count: Int` の `>= 2` invariant を `init { require(count >= 2) }` で表現

**4 項目品質ゲート (全 green)**:

- `./gradlew ktlintFormat ktlintCheck --continue` — exit=0
- `./gradlew jvmTest --rerun-tasks --continue` — exit=0
- `./gradlew :compiler-plugin:test --rerun-tasks --continue` — exit=0 (`HintCrossArtifactAndSquattingTest` 含む全 30 task 実行)
- `./gradlew apiCheck --continue` — exit=0 (public API 不変)

---

## Iter 後追加対応: Copilot review thread `PRRT_kwDOOftTdM6A9CBo`

`.claude/rules/compiler-plugin-error.md:163` の Bad WARNING example が Ticket 1 restructure 前の path `compiler-plugin/.../ir/HintDiscovery.kt` を参照していた指摘を反映。

**1 commit 追加**:

- `a41d26b1 docs(rules): update Bad WARNING example path to current location`
  - Bad WARNING example の path を post Ticket 1 layout (`compiler-plugin/.../feature/previewCollection/ir/collectPreviewsReplacement/DiscoverHints.kt`) に更新
  - rule docs 内に `ir/HintDiscovery` への他の drift がないことも `grep -rn` で確認済

**4 項目品質ゲート (全 green)**:

- `./gradlew ktlintFormat ktlintCheck --continue` — exit=0 (`BUILD SUCCESSFUL`)
- `./gradlew jvmTest --rerun-tasks --continue` — exit=0 (`BUILD SUCCESSFUL`)
- `./gradlew :compiler-plugin:test --rerun-tasks --continue` — exit=0 (`BUILD SUCCESSFUL`)
- `./gradlew apiCheck --continue` — exit=0 (`BUILD SUCCESSFUL`、 public API 不変)

**review thread**:

- `PRRT_kwDOOftTdM6A9CBo` — reply + `resolveReviewThread` 実行済 (`isResolved: true`)
