### PR TITLE
refactor(compiler-plugin/test): feature/logic 別に test を再配置

### DIFF
--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/AggregationTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/AggregationTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/CollectPreviewsTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/CollectPreviewsTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/CollectedPreviewMetadataTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/CollectedPreviewMetadataTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/CrossModuleAggregationKlibTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/CrossModuleAggregationKlibTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection
 
 import com.tschuchort.compiletesting.SourceFile
 import io.kotest.core.spec.style.FunSpec

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/CrossModuleAggregationTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/CrossModuleAggregationTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/PreviewDiscoveryTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/PreviewDiscoveryTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/PreviewHintEnabledFlagTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/PreviewHintEnabledFlagTest.kt
@@ -10,8 +10,8 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import me.tbsten.compose.preview.lab.compiler.CompilerPluginTestBase
-import me.tbsten.compose.preview.lab.compiler.feature.previewHintFacadeFiles
-import me.tbsten.compose.preview.lab.compiler.feature.previewHintMarkerFiles
+import me.tbsten.compose.preview.lab.compiler.utils.previewHintFacadeFiles
+import me.tbsten.compose.preview.lab.compiler.utils.previewHintMarkerFiles
 import me.tbsten.compose.preview.lab.compiler.isAtLeast
 import me.tbsten.compose.preview.lab.compiler.loadCollectedPreviews
 

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/PreviewHintEnabledFlagTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/PreviewHintEnabledFlagTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.PluginOption
@@ -10,6 +10,8 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import me.tbsten.compose.preview.lab.compiler.CompilerPluginTestBase
+import me.tbsten.compose.preview.lab.compiler.feature.previewHintFacadeFiles
+import me.tbsten.compose.preview.lab.compiler.feature.previewHintMarkerFiles
 import me.tbsten.compose.preview.lab.compiler.isAtLeast
 import me.tbsten.compose.preview.lab.compiler.loadCollectedPreviews
 

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/PreviewHintScopeTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/PreviewHintScopeTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
@@ -8,6 +8,7 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import me.tbsten.compose.preview.lab.compiler.CompilerPluginTestBase
+import me.tbsten.compose.preview.lab.compiler.feature.previewHintFacadeNames
 import me.tbsten.compose.preview.lab.compiler.isAtLeast
 import me.tbsten.compose.preview.lab.compiler.loadCollectedPreviews
 

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/PreviewHintScopeTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/PreviewHintScopeTest.kt
@@ -8,7 +8,7 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import me.tbsten.compose.preview.lab.compiler.CompilerPluginTestBase
-import me.tbsten.compose.preview.lab.compiler.feature.previewHintFacadeNames
+import me.tbsten.compose.preview.lab.compiler.utils.previewHintFacadeNames
 import me.tbsten.compose.preview.lab.compiler.isAtLeast
 import me.tbsten.compose.preview.lab.compiler.loadCollectedPreviews
 

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/UnsupportedKotlinErrorTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/UnsupportedKotlinErrorTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintAndMarkerGeneration/PreviewHintMarkerSealOrHiddenTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintAndMarkerGeneration/PreviewHintMarkerSealOrHiddenTest.kt
@@ -5,7 +5,7 @@ import com.tschuchort.compiletesting.SourceFile
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import me.tbsten.compose.preview.lab.compiler.CompilerPluginTestBase
-import me.tbsten.compose.preview.lab.compiler.feature.previewHintMarkerNames
+import me.tbsten.compose.preview.lab.compiler.utils.previewHintMarkerNames
 import me.tbsten.compose.preview.lab.compiler.isAtLeast
 import java.io.File
 

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintAndMarkerGeneration/PreviewHintMarkerSealOrHiddenTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintAndMarkerGeneration/PreviewHintMarkerSealOrHiddenTest.kt
@@ -1,10 +1,11 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection.fir.hintAndMarkerGeneration
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import me.tbsten.compose.preview.lab.compiler.CompilerPluginTestBase
+import me.tbsten.compose.preview.lab.compiler.feature.previewHintMarkerNames
 import me.tbsten.compose.preview.lab.compiler.isAtLeast
 import java.io.File
 

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintGeneration/BacktickIdentifierSanitizationTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintGeneration/BacktickIdentifierSanitizationTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection.fir.hintGeneration
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintGeneration/PreviewHintEmissionTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintGeneration/PreviewHintEmissionTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection.fir.hintGeneration
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintGeneration/PreviewHintHiddenDeprecationTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintGeneration/PreviewHintHiddenDeprecationTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection.fir.hintGeneration
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
@@ -7,6 +7,8 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
 import me.tbsten.compose.preview.lab.compiler.CompilerPluginTestBase
+import me.tbsten.compose.preview.lab.compiler.feature.previewHintFacadeNames
+import me.tbsten.compose.preview.lab.compiler.feature.previewHintMarkerNames
 import me.tbsten.compose.preview.lab.compiler.isAtLeast
 
 /**

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintGeneration/PreviewHintHiddenDeprecationTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintGeneration/PreviewHintHiddenDeprecationTest.kt
@@ -7,8 +7,8 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
 import me.tbsten.compose.preview.lab.compiler.CompilerPluginTestBase
-import me.tbsten.compose.preview.lab.compiler.feature.previewHintFacadeNames
-import me.tbsten.compose.preview.lab.compiler.feature.previewHintMarkerNames
+import me.tbsten.compose.preview.lab.compiler.utils.previewHintFacadeNames
+import me.tbsten.compose.preview.lab.compiler.utils.previewHintMarkerNames
 import me.tbsten.compose.preview.lab.compiler.isAtLeast
 
 /**

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintGeneration/PreviewHintScopeIgnoreInteropTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintGeneration/PreviewHintScopeIgnoreInteropTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection.fir.hintGeneration
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/scopeValidation/DefaultCollectScopeDslTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/scopeValidation/DefaultCollectScopeDslTest.kt
@@ -9,7 +9,7 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import me.tbsten.compose.preview.lab.compiler.CompilerPluginTestBase
-import me.tbsten.compose.preview.lab.compiler.feature.previewHintFacadeNames
+import me.tbsten.compose.preview.lab.compiler.utils.previewHintFacadeNames
 import me.tbsten.compose.preview.lab.compiler.isAtLeast
 import me.tbsten.compose.preview.lab.compiler.loadCollectedPreviews
 

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/scopeValidation/DefaultCollectScopeDslTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/scopeValidation/DefaultCollectScopeDslTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection.fir.scopeValidation
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.PluginOption
@@ -9,6 +9,7 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import me.tbsten.compose.preview.lab.compiler.CompilerPluginTestBase
+import me.tbsten.compose.preview.lab.compiler.feature.previewHintFacadeNames
 import me.tbsten.compose.preview.lab.compiler.isAtLeast
 import me.tbsten.compose.preview.lab.compiler.loadCollectedPreviews
 

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/scopeValidation/PreviewHintScopeValidationTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/scopeValidation/PreviewHintScopeValidationTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection.fir.scopeValidation
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/HintCrossArtifactAndSquattingTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/HintCrossArtifactAndSquattingTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection.ir.collectPreviewsReplacement
 
 import com.tschuchort.compiletesting.SourceFile
 import io.kotest.core.spec.style.FunSpec

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/HintHashCollisionTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/HintHashCollisionTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection.ir.collectPreviewsReplacement
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/PreviewHintDiscoveryTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/PreviewHintDiscoveryTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection.ir.collectPreviewsReplacement
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/PreviewHintIgnoreCrossModuleTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/PreviewHintIgnoreCrossModuleTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection.ir.collectPreviewsReplacement
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
@@ -8,6 +8,8 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import me.tbsten.compose.preview.lab.compiler.CompilerPluginTestBase
+import me.tbsten.compose.preview.lab.compiler.feature.previewHintFacadeFiles
+import me.tbsten.compose.preview.lab.compiler.feature.previewHintMarkerFiles
 import me.tbsten.compose.preview.lab.compiler.isAtLeast
 import me.tbsten.compose.preview.lab.compiler.loadCollectedPreviews
 

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/PreviewHintIgnoreCrossModuleTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/PreviewHintIgnoreCrossModuleTest.kt
@@ -8,8 +8,8 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import me.tbsten.compose.preview.lab.compiler.CompilerPluginTestBase
-import me.tbsten.compose.preview.lab.compiler.feature.previewHintFacadeFiles
-import me.tbsten.compose.preview.lab.compiler.feature.previewHintMarkerFiles
+import me.tbsten.compose.preview.lab.compiler.utils.previewHintFacadeFiles
+import me.tbsten.compose.preview.lab.compiler.utils.previewHintMarkerFiles
 import me.tbsten.compose.preview.lab.compiler.isAtLeast
 import me.tbsten.compose.preview.lab.compiler.loadCollectedPreviews
 

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/buildPreviewSequence/SourceTextExtractionTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/buildPreviewSequence/SourceTextExtractionTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.previewCollection.ir.collectPreviewsReplacement.buildPreviewSequence
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/transformPrivatePreviewToInternal/fir/visibilityPromotion/VisibilityTransformTest.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/feature/transformPrivatePreviewToInternal/fir/visibilityPromotion/VisibilityTransformTest.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.feature.transformPrivatePreviewToInternal.fir.visibilityPromotion
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile

--- a/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/utils/PreviewHintTestSupport.kt
+++ b/compiler-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/compiler/utils/PreviewHintTestSupport.kt
@@ -1,4 +1,4 @@
-package me.tbsten.compose.preview.lab.compiler.feature
+package me.tbsten.compose.preview.lab.compiler.utils
 
 import java.io.File
 


### PR DESCRIPTION
## 概要

Ticket 2 の実装。`compiler-plugin/src/test/` 配下の **23 ファイル** を、 Ticket 1 (PR #200) で確定した production の `feature × logic` 構造に sync する。test 内容に基づいて feature/logic 別に再配置し、 package 宣言を新パスに合わせて更新した。

- **base PR**: #200 (Ticket 1)
- **ticket**: `.local/ticket/compiler-plugin-restructure-2-tests.md`
- **規模実測**: 23 files changed, +32 / -23 (`git mv` による pure rename 中心、 package 更新 + import 追加が差分)

## 再配置マップ

### `feature/transformPrivatePreviewToInternal/fir/visibilityPromotion/` (1 file)

- `VisibilityTransformTest.kt`

### `feature/previewCollection/` 直下 — logic 横断 e2e (9 files)

| ファイル | 意図 |
|---|---|
| `AggregationTest.kt` | collect の e2e |
| `CollectPreviewsTest.kt` | 同上 |
| `CollectedPreviewMetadataTest.kt` | 同上 |
| `CrossModuleAggregationTest.kt` | cross-module e2e |
| `CrossModuleAggregationKlibTest.kt` | cross-module e2e (klib) |
| `PreviewDiscoveryTest.kt` | `@Preview` 検出 e2e |
| `PreviewHintEnabledFlagTest.kt` | enabled flag emit/collect 双方の e2e (PR #186) |
| `PreviewHintScopeTest.kt` | scope-aware emit + IR collect の e2e (PR #187) |
| `UnsupportedKotlinErrorTest.kt` | Kotlin version gate の e2e |

### `feature/previewCollection/fir/<logic>/` (7 files)

- **`hintGeneration/`**: `PreviewHintEmissionTest.kt` / `PreviewHintHiddenDeprecationTest.kt` / `PreviewHintScopeIgnoreInteropTest.kt` / `BacktickIdentifierSanitizationTest.kt`
- **`hintAndMarkerGeneration/`**: `PreviewHintMarkerSealOrHiddenTest.kt`
- **`scopeValidation/`**: `PreviewHintScopeValidationTest.kt` / `DefaultCollectScopeDslTest.kt`

### `feature/previewCollection/ir/<logic>/` (5 files)

- **`collectPreviewsReplacement/`**: `PreviewHintDiscoveryTest.kt` / `PreviewHintIgnoreCrossModuleTest.kt` / `HintHashCollisionTest.kt` / `HintCrossArtifactAndSquattingTest.kt`
- **`collectPreviewsReplacement/buildPreviewSequence/`**: `SourceTextExtractionTest.kt`

### `utils/` (1 file)

- `PreviewHintTestSupport.kt` (`feature/` から `utils/` へ移動、 6 ファイルの import を新パスに追従更新)

## Commit 構成

1. `c9d60457` — VisibilityTransformTest を `transformPrivatePreviewToInternal/fir/visibilityPromotion/` へ
2. `b8bc0cb7` — logic 横断 e2e 9 ファイルを `previewCollection/` 直下へ
3. `a1255aef` — FIR テストを logic 別 (hintGeneration / hintAndMarkerGeneration / scopeValidation) に分割
4. `8d7dcf47` — IR テストを logic 別 (collectPreviewsReplacement / buildPreviewSequence) に分割
5. `90c04312` — `PreviewHintTestSupport.kt` を `utils/` へ移動 + 6 consumer の import を追従更新

## 設計逸脱

**Ticket 仕様の `fir/markerGeneration/` ではなく `fir/hintAndMarkerGeneration/` を採用**。

Ticket では marker interface 生成を独立 logic として切り出す前提だったが、 Ticket 1 land 時点の production は `PreviewHintFirGenerator` を分割せず hint stub + marker interface 生成を同 generator にまとめた `fir/hintAndMarkerGeneration/` 構造に確定した (production 側で SSoT 化された結果)。 本チケットの目的は **production 構造への sync** なので、 production の確定構造に合わせて `PreviewHintMarkerSealOrHiddenTest.kt` の配置先を `fir/hintAndMarkerGeneration/` とした。

その他の点 (`fir/hintGeneration/` / `fir/scopeValidation/` / `ir/collectPreviewsReplacement/` / `ir/collectPreviewsReplacement/buildPreviewSequence/` / `utils/`) は Ticket 仕様と production がそのまま一致。

## 検証 (Ticket 「動作確認方法 5 項目以上」 全 7 項目)

各 commit ごとに以下を確認、 **全 commit で green**:

| # | 項目 | 結果 |
|---|---|---|
| 1 | `git log --follow` で旧パスからの履歴が連続 | `git mv` で 23 ファイル全て pure rename (`git diff --stat` の `{}` 表記で確認可能) |
| 2 | `contract/` 未 touch | `git diff --name-only -- compiler-plugin/.../contract/` が空 |
| 3 | package と path 一致 | feature 配下 22 ファイル + utils 配下 1 ファイルで完全一致 |
| 4 | test 件数の保存 | 全 commit で `total tests: 131` (move 前後で同一) |
| 5 | `PreviewHintTestSupport` 参照解決 | 6 consumer 全てが新 import (`me.tbsten.compose.preview.lab.compiler.utils.previewHint*`) を使い test 全 pass |
| 6 | CI 同等 (`:compiler-plugin:test --rerun-tasks`) | 全 commit で BUILD SUCCESSFUL |
| 7 | kctfork 基盤未 touch | `git diff --name-only -- .../CompilerPluginTestBase.kt .../CompilerPluginJsTestBase.kt .../KotlinVersionUtil.kt` 空 |

### 4 項目品質ゲート (各 commit ごと)

- `:compiler-plugin:ktlintFormat` + `:compiler-plugin:ktlintCheck` — pass
- `:compiler-plugin:test --rerun-tasks --continue` — pass (131 tests)
- `apiCheck` — pass
- `find compiler-plugin -name build/api -type d` — `compat-k*/build/api/` 以外ゼロ

### 追加チェック

- **wildcard import 増加ゼロ**: `git diff -- '*.kt' | grep '^\+import .*\.\*$'` 空
- **PreviewHintTestSupport の internal extension 修飾子は不変**: 同 source set 内参照のため `internal` 維持で動作

## 既知の警告 (本 PR と無関係)

`:compiler-plugin:test` 実行時の `Call uses reflection API which is not found in compilation classpath` 警告は kctfork (`KotlinCompilation`) のクラスパス警告で、 本 PR 以前から既存。 テスト用 source の中で `::class.qualifiedName` 等を使う箇所で出力されるが、 動作には影響しない。

<details>
<summary>Self-Review Log</summary>

### 進め方の振り返り

- 各 commit で 5 つの品質ゲート (ktlintFormat / ktlintCheck / test --rerun-tasks / apiCheck / build/api check + wildcard import check) を毎回実行
- `git mv` で history 連続性を担保し、 package 宣言を別ステップで更新することで `git log --follow` の追跡を維持
- `PreviewHintTestSupport.kt` の utils/ への移動は最後の commit に置くことで、 中間 commit でも `internal` extension への参照が壊れない設計 (途中段階では `import me.tbsten.compose.preview.lab.compiler.feature.previewHint*` で参照)

### 設計判断の記録

- **Ticket と production の差異 (`markerGeneration` vs `hintAndMarkerGeneration`)**: Ticket は計画段階の logic 分解を示すが、 Ticket 1 で `PreviewHintFirGenerator` を非分割で land した結果、 production 側で `hintAndMarkerGeneration/` に統合。 SSoT 視点では production が真。 本 PR は production に追従した
- **`scopeValidation/` 配下に `DefaultCollectScopeDslTest.kt` を置いた**: Ticket では「同上 or feature 直下 (DSL 検証寄り)」と曖昧な指示。 production の `fir/scopeValidation/ScopeValidationRegex.kt` 等と論点が同じ (DSL/sentinel の validation) なので logic 配下に統一
- **`PreviewHintScopeIgnoreInteropTest.kt` は `hintGeneration/`**: scope と `@ComposePreviewLabOption(ignored)` の interop が emit 側 (PreviewHintFirGenerator) の挙動なので

### 品質ゲート結果 (commit ごと total tests = 131)

| commit | ktlintCheck | test | apiCheck | build/api | wildcard |
|---|---|---|---|---|---|
| c9d60457 | pass | 131 pass | pass | OK | none |
| b8bc0cb7 | pass | 131 pass | pass | OK | none |
| a1255aef | pass | 131 pass | pass | OK | none |
| 8d7dcf47 | pass | 131 pass | pass | OK | none |
| 90c04312 | pass | 131 pass | pass | OK | none |

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)