### PR TITLE
fix(ci): nightly 通知の詳細を Discord thread に流す

### DIFF
--- a/.github/scripts/discord-notify.js
+++ b/.github/scripts/discord-notify.js
@@ -8,19 +8,29 @@
 //   ACTIONS_URL             : Actions Run の URL
 //   ISSUES_DIR              : .local/nightly-exploration/issues
 //   DISCORD_WEBHOOK_URL     : Discord webhook URL (必須)
+//   DISCORD_THREAD_ID       : (任意) 既存 thread の ID。 指定があればその thread に投稿する
+//   DISCORD_THREAD_NAME     : (任意) thread の名前。 デフォルトは "Nightly Checking YYYY-MM-DD"
 //
 // 動作:
 //   1. issue Markdown ファイルからタイトル / メタ行 / 詳細を抽出
-//   2. PBT セクションと探索的テストセクションを条件付きで組み立て
-//   3. Discord の 2000 文字制限を超えそうなら行単位で 1900 文字ごとに分割し、
-//      同じチャンネルへ順次連投 (webhook で thread を作るのはチャンネル種別依存のため、
-//      連投で代替する)。
+//   2. **1 通目**: チャンネル本体に **短いサマリ** (PBT セクション + 探索的テストヘッダー)
+//      を送る。 詳細 issue は含めない。 探索的テスト issue があるときは thread を作る or
+//      既存 thread を使う。
+//   3. **2 通目以降**: 詳細 issue の `## 探索的テスト N. ...` を thread に流す。
+//      thread が確保できなかった場合は最終手段としてチャンネルに連投する。
+//
+// thread の確保方法:
+//   - `DISCORD_THREAD_ID` があれば既存 thread に投稿
+//   - 無ければ `?thread_name=` を 1 通目に付けて新規 thread を作る (forum/media channel 前提)
+//     → 1 通目のレスポンスから channel_id (= 新しく作られた thread の ID) を拾って続きで使う
+//   - どちらも駄目だった場合のみ、 詳細をチャンネルに連投するフォールバック
 
 const fs = require('fs');
 const path = require('path');
 
 const CHUNK_LIMIT = 1900;
 const CONTENT_LIMIT = 1990;
+const THREAD_NAME_LIMIT = 100;
 
 function extractIssue(filePath) {
     const text = fs.readFileSync(filePath, 'utf8');
@@ -60,48 +70,55 @@ function extractIssue(filePath) {
     return { title, meta, detail };
 }
 
-function buildSections(env) {
-    const sections = [];
+function readIssues(issuesDir) {
+    if (!fs.existsSync(issuesDir)) return [];
+    return fs
+        .readdirSync(issuesDir)
+        .filter((f) => f.endsWith('.md'))
+        .sort()
+        .map((f) => extractIssue(path.join(issuesDir, f)));
+}
+
+function buildSummary(env, issues) {
+    // 1 通目: チャンネル本体に出すサマリ。 詳細 issue は含めない。
+    const lines = [];
 
     if (env.SEND_PBT === 'true') {
-        const lines = ['# PBT', `ステータス: ${env.PBT_RESULT || '(unknown)'}`];
-        if (env.ACTIONS_URL) {
-            lines.push(`Actions: ${env.ACTIONS_URL}`);
-        }
-        sections.push(lines.join('\n'));
+        lines.push('# PBT');
+        lines.push(`ステータス: ${env.PBT_RESULT || '(unknown)'}`);
+        if (env.ACTIONS_URL) lines.push(`Actions: ${env.ACTIONS_URL}`);
     }
 
     if (env.SEND_EXP === 'true') {
-        const lines = ['# 探索的テスト'];
+        if (lines.length > 0) lines.push('');
+        lines.push('# 探索的テスト');
         if (env.EXP_RESULT === 'failure' || env.EXP_RESULT === 'cancelled') {
-            lines.push('(探索ジョブが失敗または途中終了しています。部分結果を表示します)');
+            lines.push('(探索ジョブが失敗または途中終了しています。 部分結果を表示します)');
         }
         lines.push(`発見件数: ${env.EXP_COUNT || '0'}件`);
-        if (env.ACTIONS_URL) {
-            lines.push(`Actions: ${env.ACTIONS_URL}`);
+        if (env.ACTIONS_URL) lines.push(`Actions: ${env.ACTIONS_URL}`);
+        if (issues.length > 0) {
+            lines.push('詳細は thread を参照してください。');
         }
-
-        const issuesDir = env.ISSUES_DIR || '.local/nightly-exploration/issues';
-        if (fs.existsSync(issuesDir)) {
-            const files = fs
-                .readdirSync(issuesDir)
-                .filter((f) => f.endsWith('.md'))
-                .sort();
-            files.forEach((f, i) => {
-                const { title, meta, detail } = extractIssue(path.join(issuesDir, f));
-                lines.push('', `## 探索的テスト ${i + 1}. ${title}`);
-                if (meta) lines.push(meta);
-                if (detail) lines.push(detail);
-            });
-        }
-
-        sections.push(lines.join('\n'));
     }
 
-    return sections;
+    return lines.join('\n');
+}
+
+function buildDetailText(issues) {
+    // 2 通目以降: 各 issue を `## 探索的テスト N. <title>` 形式で並べる。
+    if (issues.length === 0) return '';
+    const blocks = issues.map((issue, i) => {
+        const block = [`## 探索的テスト ${i + 1}. ${issue.title}`];
+        if (issue.meta) block.push(issue.meta);
+        if (issue.detail) block.push(issue.detail);
+        return block.join('\n');
+    });
+    return blocks.join('\n\n');
 }
 
 function splitIntoChunks(fullText, chunkLimit) {
+    if (!fullText) return [];
     const lines = fullText.split('\n');
     const chunks = [];
     let current = '';
@@ -114,38 +131,45 @@ function splitIntoChunks(fullText, chunkLimit) {
             current = candidate;
         }
     }
-    if (current.length > 0) {
-        chunks.push(current);
-    }
+    if (current.length > 0) chunks.push(current);
     return chunks;
 }
 
-async function postChunk(webhook, content, idx, core) {
-    let body = content;
-    if (body.length > CONTENT_LIMIT) {
-        body = body.slice(0, CONTENT_LIMIT - 5) + '...';
-    }
-    const res = await fetch(webhook, {
+function todayYmd() {
+    return new Date().toISOString().slice(0, 10);
+}
+
+function buildWebhookUrl(webhook, { threadId, threadName, wait } = {}) {
+    const url = new URL(webhook);
+    if (wait) url.searchParams.set('wait', 'true');
+    if (threadId) url.searchParams.set('thread_id', threadId);
+    if (threadName) url.searchParams.set('thread_name', threadName.slice(0, THREAD_NAME_LIMIT));
+    return url.toString();
+}
+
+function truncateContent(content) {
+    if (content.length <= CONTENT_LIMIT) return content;
+    return content.slice(0, CONTENT_LIMIT - 5) + '...';
+}
+
+async function postMessage(webhook, content, opts, core) {
+    const url = buildWebhookUrl(webhook, opts);
+    const body = truncateContent(content);
+    const res = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ content: body, allowed_mentions: { parse: [] } }),
     });
     if (!res.ok) {
-        const text = await res.text();
-        throw new Error(`Discord POST chunk #${idx} failed: HTTP ${res.status} ${text}`);
+        const text = await res.text().catch(() => '');
+        throw new Error(`Discord POST failed: HTTP ${res.status} ${text}`);
     }
-    core.info(`Posted chunk #${idx} (${body.length} chars)`);
-}
-
-async function sendFallback(webhook, actionsUrl, core) {
-    const content = [
-        '# Nightly Checking',
-        '通知ペイロードを生成できませんでした。詳細は Actions を参照してください。',
-        actionsUrl,
-    ]
-        .filter(Boolean)
-        .join('\n');
-    await postChunk(webhook, content, 0, core);
+    core.info(`Posted ${body.length} chars${opts.threadId ? ` (thread=${opts.threadId})` : opts.threadName ? ` (new thread="${opts.threadName}")` : ''}`);
+    if (opts.wait) {
+        const json = await res.json().catch(() => null);
+        return json;
+    }
+    return null;
 }
 
 module.exports = async function notifyDiscord({ core, env = process.env }) {
@@ -155,30 +179,80 @@ module.exports = async function notifyDiscord({ core, env = process.env }) {
         return;
     }
 
-    const sections = buildSections(env);
-    if (sections.length === 0) {
-        core.info(
-            `No content to send (SEND_PBT=${env.SEND_PBT}, SEND_EXP=${env.SEND_EXP}). Skipping.`,
-        );
+    const sendPbt = env.SEND_PBT === 'true';
+    const sendExp = env.SEND_EXP === 'true';
+    if (!sendPbt && !sendExp) {
+        core.info(`No content to send (SEND_PBT=${env.SEND_PBT}, SEND_EXP=${env.SEND_EXP}). Skipping.`);
         return;
     }
 
-    const fullText = sections.join('\n\n');
-    const chunks = splitIntoChunks(fullText, CHUNK_LIMIT);
+    const issues = sendExp ? readIssues(env.ISSUES_DIR || '.local/nightly-exploration/issues') : [];
+    const summary = buildSummary(env, issues);
+    const detailText = buildDetailText(issues);
 
-    if (chunks.length === 0) {
-        await sendFallback(webhook, env.ACTIONS_URL, core);
+    const presetThreadId = (env.DISCORD_THREAD_ID || '').trim() || null;
+    const threadName =
+        (env.DISCORD_THREAD_NAME || '').trim() || `Nightly Checking ${todayYmd()}`;
+
+    const wantsThread = detailText.length > 0;
+
+    // 1 通目: サマリ。
+    // - DISCORD_THREAD_ID 指定なし: チャンネル本体に投稿。 wantsThread なら同時に
+    //   `thread_name` を渡して forum/media channel での新規 thread 作成を狙う。
+    // - DISCORD_THREAD_ID 指定あり: 全部その thread に投稿する。
+    const summaryOpts = presetThreadId
+        ? { threadId: presetThreadId, wait: true }
+        : wantsThread
+            ? { threadName, wait: true }
+            : { wait: false };
+
+    let resolvedThreadId = presetThreadId;
+    try {
+        const firstResponse = await postMessage(webhook, summary, summaryOpts, core);
+        if (!resolvedThreadId && firstResponse && firstResponse.channel_id) {
+            // forum/media channel で thread_name を指定すると、 レスポンスの channel_id が
+            // 新たに作られた thread の ID になる。
+            resolvedThreadId = firstResponse.channel_id;
+        }
+    } catch (err) {
+        // thread_name 付きの 1 通目が失敗した場合 (= forum channel ではなかった等):
+        // thread を諦めて、 thread_name なしで再送する。
+        if (summaryOpts.threadName) {
+            core.warning(
+                `1 通目が thread_name 付きで失敗 (${err.message})。 thread_name を外して再送します。`,
+            );
+            await postMessage(webhook, summary, { wait: false }, core);
+            resolvedThreadId = null;
+        } else {
+            throw err;
+        }
+    }
+
+    if (!wantsThread) {
+        core.info('Discord notification done (summary only).');
         return;
     }
 
-    core.info(`Prepared ${chunks.length} chunk(s) for Discord.`);
-    for (let i = 0; i < chunks.length; i++) {
-        await postChunk(webhook, chunks[i], i + 1, core);
-        if (i + 1 < chunks.length) {
+    // 2 通目以降: 詳細を thread に流す。 thread 確保できなかった場合はチャンネル連投。
+    const detailChunks = splitIntoChunks(detailText, CHUNK_LIMIT);
+    core.info(`Detail split into ${detailChunks.length} chunk(s).`);
+
+    for (let i = 0; i < detailChunks.length; i++) {
+        const opts = resolvedThreadId ? { threadId: resolvedThreadId } : {};
+        await postMessage(webhook, detailChunks[i], opts, core);
+        if (i + 1 < detailChunks.length) {
             await new Promise((r) => setTimeout(r, 1000));
         }
     }
+
     core.info('Discord notification done.');
 };
 
-module.exports._internal = { extractIssue, buildSections, splitIntoChunks };
+module.exports._internal = {
+    extractIssue,
+    readIssues,
+    buildSummary,
+    buildDetailText,
+    splitIntoChunks,
+    buildWebhookUrl,
+};

--- a/.github/scripts/discord-notify.js
+++ b/.github/scripts/discord-notify.js
@@ -132,9 +132,8 @@ function buildSummary(env, issues) {
         }
         lines.push(`発見件数: ${env.EXP_COUNT || '0'}件`);
         if (env.ACTIONS_URL) lines.push(`Actions: ${env.ACTIONS_URL}`);
-        if (issues.length > 0) {
-            lines.push('詳細は thread を参照してください。');
-        }
+        // 「詳細は thread を参照」 の案内は ルーティング結果が確定した後で
+        // 呼び出し側 (notifyDiscord) が付与する。 ここでは付けない。
     }
 
     return lines.join('\n');
@@ -231,30 +230,43 @@ module.exports = async function notifyDiscord({ core, env = process.env }) {
 
     const wantsThread = detailText.length > 0;
 
-    // 1 通目: サマリ。
-    // - DISCORD_THREAD_ID 指定なし: チャンネル本体に投稿。 wantsThread なら同時に
-    //   `thread_name` を渡して forum/media channel での新規 thread 作成を狙う。
-    // - DISCORD_THREAD_ID 指定あり: 全部その thread に投稿する。
-    const summaryOpts = presetThreadId
-        ? { threadId: presetThreadId, wait: true }
-        : wantsThread
-            ? { threadName, wait: true }
-            : { wait: false };
-
+    // 1 通目のルーティングと文言を、 thread が確保できる経路かどうかで出し分ける。
+    // - DISCORD_THREAD_ID 指定あり: summary も詳細も同じ thread に投稿。 案内文不要
+    //   (summary 自体が thread 内にあるので "詳細は thread を参照" は意味をなさない)。
+    // - 指定なし & 詳細あり: 1 通目に `thread_name` を付けて新規 thread 作成を狙う。
+    //   1 通目はチャンネル本体に残るため、 「詳細は thread を参照」 の案内文を付ける。
+    // - 指定なし & 詳細なし: チャンネルに summary だけ。 案内文なし。
+    // - 上の thread_name 投稿が HTTP エラーになった場合: 案内文を外した summary を
+    //   channel に再送し、 詳細もチャンネル連投にフォールバック。
     let resolvedThreadId = presetThreadId;
+    const summaryWithNote = `${summary}\n詳細は thread を参照してください。`;
+
+    let summaryToPost;
+    let summaryOpts;
+    if (presetThreadId) {
+        summaryToPost = summary;
+        summaryOpts = { threadId: presetThreadId, wait: false };
+    } else if (wantsThread) {
+        summaryToPost = summaryWithNote;
+        summaryOpts = { threadName, wait: true };
+    } else {
+        summaryToPost = summary;
+        summaryOpts = { wait: false };
+    }
+
     try {
-        const firstResponse = await postMessage(webhook, summary, summaryOpts, core);
+        const firstResponse = await postMessage(webhook, summaryToPost, summaryOpts, core);
         if (!resolvedThreadId && firstResponse && firstResponse.channel_id) {
             // forum/media channel で thread_name を指定すると、 レスポンスの channel_id が
             // 新たに作られた thread の ID になる。
             resolvedThreadId = firstResponse.channel_id;
         }
     } catch (err) {
-        // thread_name 付きの 1 通目が失敗した場合 (= forum channel ではなかった等):
-        // thread を諦めて、 thread_name なしで再送する。
         if (summaryOpts.threadName) {
+            // 通常のテキストチャンネル等で thread_name が拒否されるケース。
+            // 案内文を外した summary を channel に再送し、 詳細はチャンネル連投にする。
             core.warning(
-                `1 通目が thread_name 付きで失敗 (${err.message})。 thread_name を外して再送します。`,
+                `1 通目が thread_name 付きで失敗 (${err.message})。 案内文を外して channel 連投にフォールバックします。`,
             );
             await postMessage(webhook, summary, { wait: false }, core);
             resolvedThreadId = null;

--- a/.github/scripts/discord-notify.js
+++ b/.github/scripts/discord-notify.js
@@ -32,6 +32,32 @@ const CHUNK_LIMIT = 1900;
 const CONTENT_LIMIT = 1990;
 const THREAD_NAME_LIMIT = 100;
 
+// 重要度の星表記。 P0 が最重要 (4 個満点) で、 番号が増えるほど星が減る。
+// issue Markdown 本体は `P0`〜`P3` のまま保持し、 Discord 通知でだけ星に変換する。
+const SEVERITY_STARS = {
+    P0: '⭐⭐⭐⭐',
+    P1: '⭐⭐⭐☆',
+    P2: '⭐⭐☆☆',
+    P3: '⭐☆☆☆',
+};
+
+// 見出しに付ける絵文字。 被らないように 3 種類を割り当てる。
+const EMOJI = {
+    pbt: '🧪', // Property-Based Test → 試験管
+    exploration: '🔍', // 探索的テスト → 虫眼鏡
+    issue: '📌', // 個別 issue → ピン留め
+};
+
+function decorateSeverity(line) {
+    // 例: `**重要度**: P1` → `**重要度**: ⭐⭐⭐☆ (P1)`
+    //     `**重要度**: P1 補足` → `**重要度**: ⭐⭐⭐☆ (P1) 補足`
+    const m = line.match(/^(\s*\*\*重要度\*\*:\s*)(P[0-3])\b(.*)$/);
+    if (!m) return line;
+    const stars = SEVERITY_STARS[m[2]];
+    if (!stars) return line;
+    return `${m[1]}${stars} (${m[2]})${m[3]}`;
+}
+
 function extractIssue(filePath) {
     const text = fs.readFileSync(filePath, 'utf8');
 
@@ -46,19 +72,28 @@ function extractIssue(filePath) {
 
     const catMatch = text.match(/^\*\*カテゴリ\*\*:.+$/m);
     const sevMatch = text.match(/^\*\*重要度\*\*:.+$/m);
+    const sevDecorated = sevMatch ? decorateSeverity(sevMatch[0]) : null;
     let meta = '';
-    if (catMatch && sevMatch) {
-        meta = `${catMatch[0]} / ${sevMatch[0]}`;
+    if (catMatch && sevDecorated) {
+        meta = `${catMatch[0]} / ${sevDecorated}`;
     } else if (catMatch) {
         meta = catMatch[0];
-    } else if (sevMatch) {
-        meta = sevMatch[0];
+    } else if (sevDecorated) {
+        meta = sevDecorated;
     }
 
+    // `## 詳細` セクションを抜き出す。 JavaScript の RegExp は `\Z` を理解しない (リテラル
+     // 扱いになる) ので、 「ヘッダの位置を探す → ヘッダ次行から、 次の `##` までを切る」
+     // という 2 段階で処理する。
     let detail = '';
-    const detailMatch = text.match(/^## 詳細\s*\r?\n([\s\S]*?)(?=^## |\Z)/m);
-    if (detailMatch) {
-        detail = detailMatch[1]
+    const detailHeaderMatch = text.match(/^## 詳細[ \t]*$/m);
+    if (detailHeaderMatch) {
+        const afterHeader = text
+            .slice(detailHeaderMatch.index + detailHeaderMatch[0].length)
+            .replace(/^\r?\n/, '');
+        const nextHeader = afterHeader.search(/^## /m);
+        const body = nextHeader >= 0 ? afterHeader.slice(0, nextHeader) : afterHeader;
+        detail = body
             .split(/\r?\n/)
             .map((l) => l.trim())
             .filter((l) => l.length > 0)
@@ -84,14 +119,14 @@ function buildSummary(env, issues) {
     const lines = [];
 
     if (env.SEND_PBT === 'true') {
-        lines.push('# PBT');
+        lines.push(`# ${EMOJI.pbt} PBT`);
         lines.push(`ステータス: ${env.PBT_RESULT || '(unknown)'}`);
         if (env.ACTIONS_URL) lines.push(`Actions: ${env.ACTIONS_URL}`);
     }
 
     if (env.SEND_EXP === 'true') {
         if (lines.length > 0) lines.push('');
-        lines.push('# 探索的テスト');
+        lines.push(`# ${EMOJI.exploration} 探索的テスト`);
         if (env.EXP_RESULT === 'failure' || env.EXP_RESULT === 'cancelled') {
             lines.push('(探索ジョブが失敗または途中終了しています。 部分結果を表示します)');
         }
@@ -109,7 +144,7 @@ function buildDetailText(issues) {
     // 2 通目以降: 各 issue を `## 探索的テスト N. <title>` 形式で並べる。
     if (issues.length === 0) return '';
     const blocks = issues.map((issue, i) => {
-        const block = [`## 探索的テスト ${i + 1}. ${issue.title}`];
+        const block = [`## ${EMOJI.issue} 探索的テスト ${i + 1}. ${issue.title}`];
         if (issue.meta) block.push(issue.meta);
         if (issue.detail) block.push(issue.detail);
         return block.join('\n');

--- a/.github/workflows/nightly-checking.yml
+++ b/.github/workflows/nightly-checking.yml
@@ -215,6 +215,10 @@ jobs:
           ACTIONS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ISSUES_DIR: .local/nightly-exploration/issues
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          # 任意: 既存 thread に投げ続けたい場合に secret として設定する。
+          # 未設定なら 1 通目に thread_name を付けて新規 thread 作成を試みる
+          # (forum/media channel 前提、 だめならチャンネル連投にフォールバック)。
+          DISCORD_THREAD_ID: ${{ secrets.DISCORD_THREAD_ID }}
         with:
           script: |
             const notify = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/discord-notify.js`);


### PR DESCRIPTION
## 背景

#201 を merge して nightly を実行したところ、 探索 issue が多いとチャンネル本体に長文が連投されてノイズになる事象が発生した。

## 主な変更

- **1 通目はチャンネル本体に短いサマリだけ** を送る形に変更:
  - `# PBT` セクション（送る場合）
  - `# 探索的テスト` ヘッダ（件数 + Actions URL + 「詳細は thread を参照」）
- **詳細 issue は thread に流す**。 thread の確保は二段構え:
  1. 任意の secret `DISCORD_THREAD_ID` が設定されていれば、 そこに固定で投稿
  2. 無ければ 1 通目に `?thread_name=Nightly Checking YYYY-MM-DD` を付けて forum / media channel 上で新規 thread 作成を狙う（レスポンスの `channel_id` を 2 通目以降の `thread_id` として利用）
  3. thread_name 投稿が HTTP エラーになった場合は thread_name を外して再送し、 詳細はチャンネル本体に連投（既存挙動）

## 補足

- 通常のテキストチャンネルで thread を分けたい場合は、 thread を 1 本手動で作って ID を `DISCORD_THREAD_ID` secret に登録すると毎晩そこへ流れる（既存 thread を再利用）
- forum / media channel に変えれば自動で nightly run ごとに新しい thread が生まれる
- どちらの設定もせずチャンネル本体に連投したい場合は、 1 通目で thread_name の HTTP エラーを踏んでフォールバックに落ちる（以前の挙動）

## 動作確認

ローカル node で `fetch` をスタブし、 以下の 4 ケースで挙動を確認済:

- [x] **Case 1**: PBT 失敗 / 探索 issue 0 件 → channel に 1 通のみ、 thread 関連パラメータ無し
- [x] **Case 2**: PBT 失敗 + 探索 issue 5 件、 preset thread 無し → 1 通目に `thread_name`、 レスポンスの `channel_id` を `thread_id` として 2 通目で再利用
- [x] **Case 3**: `DISCORD_THREAD_ID=preset-thread-999` 指定 → 1 通目から指定 thread に投稿、 2 通目も同 thread
- [x] **Case 4**: 1 通目で `thread_name` 付き投稿が HTTP 400 → `thread_name` を外して再送、 詳細はチャンネル連投にフォールバック

🤖 Generated with [Claude Code](https://claude.com/claude-code)