### PR TITLE
fix(ci): Discord forum channel での thread 作成 + Claude Opus 切り替え

### DIFF
--- a/.github/scripts/discord-notify.js
+++ b/.github/scripts/discord-notify.js
@@ -176,11 +176,14 @@ function splitIntoChunks(fullText, chunkLimit) {
     return chunks;
 }
 
-function buildWebhookUrl(webhook, { threadId, threadName, wait } = {}) {
+function buildWebhookUrl(webhook, { threadId, wait } = {}) {
+    // Discord 仕様: `thread_id` は URL クエリで渡すが、 `thread_name` は **JSON body** に
+    // 入れる必要がある。 URL クエリに thread_name を付けても無視され、 forum channel への
+    // 投稿は 400 ("must have a thread_name or thread_id") になる。
+    // そのため thread_name は呼び出し側で body に積み、 この関数は thread_id と wait のみ扱う。
     const url = new URL(webhook);
     if (wait) url.searchParams.set('wait', 'true');
     if (threadId) url.searchParams.set('thread_id', threadId);
-    if (threadName) url.searchParams.set('thread_name', threadName.slice(0, THREAD_NAME_LIMIT));
     return url.toString();
 }
 
@@ -190,12 +193,17 @@ function truncateContent(content) {
 }
 
 async function postMessage(webhook, content, opts, core) {
-    const url = buildWebhookUrl(webhook, opts);
+    const url = buildWebhookUrl(webhook, { threadId: opts.threadId, wait: opts.wait });
     const body = truncateContent(content);
+    const payload = { content: body, allowed_mentions: { parse: [] } };
+    if (opts.threadName) {
+        // `thread_name` は URL クエリではなく body に入れる (Discord 仕様)。
+        payload.thread_name = opts.threadName.slice(0, THREAD_NAME_LIMIT);
+    }
     const res = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: body, allowed_mentions: { parse: [] } }),
+        body: JSON.stringify(payload),
     });
     if (!res.ok) {
         const text = await res.text().catch(() => '');

--- a/.github/workflows/nightly-checking.yml
+++ b/.github/workflows/nightly-checking.yml
@@ -133,7 +133,9 @@ jobs:
             - 各 issue は SKILL.md と references/issue-format.md の固定フォーマットに従う
             - 60 分以内に完了させる。50 分時点で新規探索を打ち切り、既存 issue の整形と書き込みを優先
             - 最後に `.local/nightly-exploration/SUMMARY.md` に件数とカテゴリ別の内訳を書き出す
-          claude_args: '--allowedTools "Bash,Edit,Glob,Grep,Read,Write,WebFetch,WebSearch"'
+          claude_args: |
+            --model opus
+            --allowedTools "Bash,Edit,Glob,Grep,Read,Write,WebFetch,WebSearch"
 
       - name: Collect issue count
         id: collect


### PR DESCRIPTION
## 背景

PR #207 merge 後、 main で nightly-checking workflow を `gh workflow run` で dispatch したところ `notify-results` ジョブが以下のエラーで失敗していた:

```
HTTP 400 {"message": "Webhooks posted to forum channels must have a thread_name or thread_id", "code": 220001}
```

参考: https://github.com/TBSten/compose-preview-lab/actions/runs/25666396648/job/75341774842

ローカルの fetch スタブテストで URL クエリ string から `thread_name` を取り出していたため、 PR #206/#207 のテストでは仕様違反を見逃していた。

## 修正内容

### 1. Discord `thread_name` を JSON body に渡すよう修正

Discord API 仕様:
- `thread_id` → URL クエリで OK
- `thread_name` → **JSON body で渡す必要がある**

これまでは `URL.searchParams.set('thread_name', ...)` で URL クエリに入れていたため、 Discord 側からは無視され「thread_name か thread_id 指定なし」 と判断されて 400。

- `buildWebhookUrl` から `threadName` 引数を削除（URL クエリには `thread_id` のみ）
- `postMessage` で `payload.thread_name` を JSON body に積むよう変更

### 2. Claude Code on GitHub Actions を Opus に切り替え

ユーザ要望に基づき探索的検証ジョブで Opus モデルを使うように `claude_args` を `|` 記法に切り替えて以下を指定:

```yaml
claude_args: |
  --model opus
  --allowedTools "Bash,Edit,Glob,Grep,Read,Write,WebFetch,WebSearch"
```

`effort=max` は Claude Code CLI に対応する公式 flag が見つからなかったため今回は見送り (API レベル設定なので Claude Code 経由では指定不可)。

## 動作確認

Discord 仕様準拠のスタブ fetch を使ってローカルで 3 経路を確認済:

- [x] **Forum channel** (`thread_name` body 受理 + channel_id が webhook と異なる) → 新 thread `🔍 探索的テスト: 発見件数 3件` 作成、 OP に summary、 thread 内に各 issue 1 message ずつ投稿
- [x] **Text channel** (`thread_name` body 受理だが channel_id が webhook と一致 = thread 作られず) → channel 連投フォールバック
- [x] **Preset `DISCORD_THREAD_ID` あり** → 全 message を指定 thread に投稿

🤖 Generated with [Claude Code](https://claude.com/claude-code)