### PR TITLE
feat(ci): nightly 結果を job summary にも書き出す

### DIFF
--- a/.github/scripts/discord-notify.js
+++ b/.github/scripts/discord-notify.js
@@ -61,6 +61,7 @@ function decorateSeverity(line) {
 
 function extractIssue(filePath) {
     const text = fs.readFileSync(filePath, 'utf8');
+    const raw = text;
 
     let title = '(タイトル未設定)';
     for (const line of text.split(/\r?\n/)) {
@@ -103,7 +104,7 @@ function extractIssue(filePath) {
             .slice(0, 200);
     }
 
-    return { title, meta, detail };
+    return { title, meta, detail, raw };
 }
 
 function readIssues(issuesDir) {
@@ -232,6 +233,52 @@ async function getWebhookChannelId(webhook) {
     }
 }
 
+// GitHub Actions の job summary に PBT と 探索的テストの結果を書き出す。
+// 各 issue は <details> で畳んで、 一覧の見通しを保つ。
+async function writeJobSummary({ core, env, issues }) {
+    if (!core || !core.summary || typeof core.summary.addHeading !== 'function') {
+        return;
+    }
+    const sendPbt = env.SEND_PBT === 'true';
+    const sendExp = env.SEND_EXP === 'true';
+    if (!sendPbt && !sendExp) return;
+
+    core.summary.addHeading('Nightly Checking 結果', 1);
+    if (env.ACTIONS_URL) {
+        core.summary.addRaw(`[Actions Run](${env.ACTIONS_URL})\n\n`);
+    }
+
+    if (sendPbt) {
+        core.summary.addHeading('🧪 PBT', 2);
+        core.summary.addRaw(`ステータス: \`${env.PBT_RESULT || '(unknown)'}\`\n\n`);
+    }
+
+    if (sendExp) {
+        core.summary.addHeading('🔍 探索的テスト', 2);
+        if (env.EXP_RESULT === 'failure' || env.EXP_RESULT === 'cancelled') {
+            core.summary.addRaw(
+                '> 探索ジョブが失敗または途中終了しています。 部分結果を表示します。\n\n',
+            );
+        }
+        core.summary.addRaw(`発見件数: **${env.EXP_COUNT || issues.length}件**\n\n`);
+
+        issues.forEach((issue, i) => {
+            // <details><summary>📌 N. <title></summary> の中に issue Markdown 全文 (H1 行を除いた本文) を入れる。
+            // 直後の空行を保って GitHub Markdown レンダリングを有効化する。
+            const summaryLabel = `📌 探索的テスト ${i + 1}. ${issue.title}`;
+            const bodyWithoutTitle = issue.raw.replace(/^#\s+.+?\r?\n+/, '').trimEnd();
+            core.summary.addDetails(summaryLabel, `\n\n${bodyWithoutTitle}\n`);
+        });
+    }
+
+    try {
+        await core.summary.write();
+    } catch (err) {
+        // job summary 書き出しはベストエフォート。 失敗しても通知本体には影響させない。
+        core.warning?.(`Job summary の書き込みに失敗: ${err.message}`);
+    }
+}
+
 module.exports = async function notifyDiscord({ core, env = process.env }) {
     const webhook = env.DISCORD_WEBHOOK_URL;
     if (!webhook) {
@@ -249,6 +296,10 @@ module.exports = async function notifyDiscord({ core, env = process.env }) {
     const issues = sendExp ? readIssues(env.ISSUES_DIR || '.local/nightly-exploration/issues') : [];
     const summary = buildSummary(env, issues);
     const detailMessages = buildDetailMessages(issues);
+
+    // Discord 通知の前に job summary を書き出しておく。 Discord 投稿が失敗しても
+    // 結果は Actions UI 上で確認できる。
+    await writeJobSummary({ core, env, issues });
 
     const presetThreadId = (env.DISCORD_THREAD_ID || '').trim() || null;
     // thread 名は探索的テストの発見件数を主題にする (forum channel で run ごとに作られる
@@ -344,4 +395,5 @@ module.exports._internal = {
     buildDetailMessages,
     splitIntoChunks,
     buildWebhookUrl,
+    writeJobSummary,
 };

--- a/.github/scripts/discord-notify.js
+++ b/.github/scripts/discord-notify.js
@@ -59,6 +59,24 @@ function decorateSeverity(line) {
     return `${m[1]}${stars} (${m[2]})${m[3]}`;
 }
 
+// `**重要度**: P1` のような行から `⭐⭐⭐☆ P1` のような短縮ラベルを取り出す。
+// <details><summary> の中など 1 行で表示する場面用 (Markdown bold は描画されないので
+// `**` を含めない)。
+function severityToShortLabel(sevLine) {
+    if (!sevLine) return null;
+    const m = sevLine.match(/P[0-3]/);
+    if (!m) return null;
+    const stars = SEVERITY_STARS[m[0]];
+    return stars ? `${stars} ${m[0]}` : m[0];
+}
+
+// `**カテゴリ**: cat2 (CI ログ・apiDump)` のような行から `cat2` だけを取り出す。
+function categoryToShortLabel(catLine) {
+    if (!catLine) return null;
+    const m = catLine.match(/cat\d+/);
+    return m ? m[0] : null;
+}
+
 function extractIssue(filePath) {
     const text = fs.readFileSync(filePath, 'utf8');
     const raw = text;
@@ -104,7 +122,11 @@ function extractIssue(filePath) {
             .slice(0, 200);
     }
 
-    return { title, meta, detail, raw };
+    // job summary の <details><summary> ラベル用に、 タイトル以外の情報を短縮形で取り出す。
+    const severityShort = severityToShortLabel(sevMatch ? sevMatch[0] : null);
+    const categoryShort = categoryToShortLabel(catMatch ? catMatch[0] : null);
+
+    return { title, meta, detail, raw, severityShort, categoryShort };
 }
 
 function readIssues(issuesDir) {
@@ -263,9 +285,14 @@ async function writeJobSummary({ core, env, issues }) {
         core.summary.addRaw(`発見件数: **${env.EXP_COUNT || issues.length}件**\n\n`);
 
         issues.forEach((issue, i) => {
-            // <details><summary>📌 N. <title></summary> の中に issue Markdown 全文 (H1 行を除いた本文) を入れる。
-            // 直後の空行を保って GitHub Markdown レンダリングを有効化する。
-            const summaryLabel = `📌 探索的テスト ${i + 1}. ${issue.title}`;
+            // <details><summary>...</summary> ラベルには 重要度 / カテゴリ / タイトル を並べ、
+            // 折りたたんだ状態でも「何がどれくらい重要か」 一目で分かるようにする。
+            // <summary> 内では Markdown bold が描画されないので `**` は使わず、 `|` 区切りで並べる。
+            const labelParts = [];
+            if (issue.severityShort) labelParts.push(issue.severityShort);
+            if (issue.categoryShort) labelParts.push(issue.categoryShort);
+            labelParts.push(issue.title);
+            const summaryLabel = `📌 ${labelParts.join(' | ')}`;
             const bodyWithoutTitle = issue.raw.replace(/^#\s+.+?\r?\n+/, '').trimEnd();
             core.summary.addDetails(summaryLabel, `\n\n${bodyWithoutTitle}\n`);
         });


### PR DESCRIPTION
## 概要

Discord 通知と同じ内容を GitHub Actions の job summary (`$GITHUB_STEP_SUMMARY`) にも書き出す。 Discord を見に行かなくても Actions UI 上で結果を確認でき、 過去 run の比較もしやすい。 探索的テストの発見が多くなりがちなので、 各 issue は `<details>` で折りたたみ、 折りたたんだ状態でも **重要度 / カテゴリ / タイトル** が一目で分かるようにする。

## 仕様

```markdown
# Nightly Checking 結果

[Actions Run](https://github.com/...)

## 🧪 PBT
ステータス: `failure`

## 🔍 探索的テスト
発見件数: **N件**

<details><summary>📌 ⭐⭐⭐☆ P1 | cat2 | BCV baseline と compat-k* に乖離</summary>

  …issue Markdown 全文 (H1 行を除く)…
</details>

<details><summary>📌 ⭐⭐⭐⭐ P0 | cat3 | 致命的な不具合</summary>

  …
</details>
```

### `<summary>` ラベル形式

| パターン | 表示例 |
|----------|--------|
| 完全メタあり | `📌 ⭐⭐⭐☆ P1 \| cat2 \| BCV baseline と compat-k* に乖離` |
| P0 (最重要) | `📌 ⭐⭐⭐⭐ P0 \| cat3 \| 致命的な不具合` |
| メタなし (フォーマット違反) | `📌 メタなしのタイトル` |

- 重要度: ⭐ 表記 + Pn段階 (P0 最重要〜P3 軽微)
- カテゴリ: `cat1`〜`cat5` の短縮形
- 区切り: `|` (Markdown bold は `<summary>` 内で描画されないので `**` は使わない)
- 順序: **重要度 → カテゴリ → タイトル** で、 重要なものを左に寄せる

### `<details>` 内側

- 元の issue Markdown 全文 (本文・再現手順・詳細・修正案)
- H1 行は summary 側に出すので raw からは除く
- 内部に空行を保って GitHub Markdown が描画される

### セクション表示条件

- PBT セクション: PBT 失敗時のみ (Discord 通知と同じ)
- 探索的テストセクション: issue が 1 件以上、 または 探索ジョブが failure/cancelled

## 実装

- `extractIssue` の戻り値に `raw` (Markdown 全文) / `severityShort` (`⭐⭐⭐☆ P1`) / `categoryShort` (`cat2`) を追加
- 新規 `severityToShortLabel` / `categoryToShortLabel` ヘルパーで `**重要度**: P1` 行から短縮形を抽出
- 新規 `writeJobSummary({core, env, issues})` を `notifyDiscord` の冒頭で呼ぶ (Discord 投稿が失敗しても summary は残る)
- `core.summary` が利用できない環境 (ローカル node 等) では no-op で skip するガード付き

## 動作確認

ローカルで `core.summary` を mock し、 以下のケースで確認済:

- [x] H1 タイトル + Actions Run リンク
- [x] PBT セクション (failure 時に表示、 ステータス埋め込み)
- [x] 探索的テスト件数 + 各 issue の `<details>` ブロック
- [x] 完全メタ issue → `📌 ⭐⭐⭐☆ P1 | cat2 | <title>` 形式
- [x] P0 issue → `📌 ⭐⭐⭐⭐ P0 | cat3 | <title>` 形式
- [x] メタなし issue → `📌 <title>` のみで fallback
- [x] `<details>` 内側で空行を保持 (GitHub Markdown 描画可能)

🤖 Generated with [Claude Code](https://claude.com/claude-code)