### PR TITLE
ci: migrate GitHub Actions to Node 24 (v5/v8) for 2026-06-02 deadline (task-031)

### DIFF
--- a/.github/workflows/clear-ci-cache.yml
+++ b/.github/workflows/clear-ci-cache.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clear CI cache
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const caches = await github.rest.actions.getActionsCacheList({

--- a/.github/workflows/nightly-checking.yml
+++ b/.github/workflows/nightly-checking.yml
@@ -38,10 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     name: PBT ${{ matrix.name }} (${{ inputs.iterations || '5000' }} iterations)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Java for Gradle
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -98,10 +98,10 @@ jobs:
       issue_count: ${{ steps.collect.outputs.issue_count }}
       has_issues: ${{ steps.collect.outputs.has_issues }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Java for Gradle
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -155,7 +155,7 @@ jobs:
 
       - name: Upload exploration artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: nightly-exploration-issues
           path: .local/nightly-exploration/
@@ -167,7 +167,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Determine sections to send
         id: decide
@@ -199,7 +199,7 @@ jobs:
 
       - name: Download exploration artifact
         if: steps.decide.outputs.send_exp == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: nightly-exploration-issues
           path: .local/nightly-exploration/
@@ -207,7 +207,7 @@ jobs:
 
       - name: Build and post Discord notification
         if: steps.decide.outputs.any == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           SEND_PBT: ${{ steps.decide.outputs.send_pbt }}
           SEND_EXP: ${{ steps.decide.outputs.send_exp }}

--- a/.github/workflows/preview-web.yml
+++ b/.github/workflows/preview-web.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Java for Gradle
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -26,13 +26,13 @@ jobs:
       - name: Save version
         run: echo "${{ steps.get_version.outputs.version }}" > ./version.txt
       - name: Upload Dokka artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dokka-docs
           path: ./dokkaDocs/build/dokka/html
           retention-days: 1
       - name: Upload version
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: version
           path: ./version.txt
@@ -42,9 +42,9 @@ jobs:
     name: Build Web Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Java for Gradle
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -69,7 +69,7 @@ jobs:
       - name: Copy web documentation to public
         run: cp -r ./docs/web/build/* ./public/
       - name: Upload web documentation artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: web-docs
           path: ./public
@@ -86,14 +86,14 @@ jobs:
       contents: write
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Download Dokka artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dokka-docs
           path: ./dokka-docs
       - name: Download version
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: version
           path: ./version
@@ -101,7 +101,7 @@ jobs:
         id: get_version
         run: echo "version=$(cat ./version/version.txt)" >> "$GITHUB_OUTPUT"
       - name: Download web documentation artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: web-docs
           path: ./web-docs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: macOS-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Java for Gradle
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Java for Gradle
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -30,9 +30,9 @@ jobs:
     name: Validate Binary Compatibility
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Java for Gradle
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -78,9 +78,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Test ${{ matrix.name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Java for Gradle
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -104,7 +104,7 @@ jobs:
     outputs:
       list: ${{ steps.read.outputs.list }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - id: read
         shell: bash
         run: |
@@ -121,9 +121,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Compiler Plugin Kotlin ${{ matrix.kotlin }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Java for Gradle
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -137,9 +137,9 @@ jobs:
     name: Publish to Maven Local
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Java for Gradle
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'


### PR DESCRIPTION
## Summary

GitHub Actions の Node.js 20 actions は **2026-06-02** から warning が error 化され、強制 Node 24 移行となる (現在 2026-05-12、残り約 21 日)。 期限前に対象 actions を v5 / v8 へ更新する。

Refs:
- Ticket: `task-031-actions-node20-deprecation`
- Origin: Nightly Exploration [run 25697742322](https://github.com/tbsten/compose-preview-lab/actions/runs/25697742322)
- GitHub Changelog: [Required: Node 24 in actions/runner](https://github.blog/changelog/) (Node 20 deprecation)

## Changes

- `actions/checkout@v4` -> `@v5`
- `actions/setup-java@v4` -> `@v5`
- `actions/upload-artifact@v4` -> `@v5`
- `actions/download-artifact@v4` -> `@v5`
- `actions/github-script@v7` -> `@v8`

対象 workflow (5 ファイル):
- `.github/workflows/nightly-checking.yml`
- `.github/workflows/pull-request.yml`
- `.github/workflows/preview-web.yml`
- `.github/workflows/clear-ci-cache.yml`
- `.github/workflows/publish.yml`

`gradle/actions/setup-gradle` は既に v5 (Node 24 対応済) のため変更なし。

## Breaking change 評価

`actions/download-artifact@v5` には [path 解釈の breaking change](https://github.com/actions/download-artifact/releases/tag/v5.0.0) があるが、**`artifact-ids:` で単独 ID download した場合のみ** 該当 (path が `path/<name>/` -> `path/` に変更)。 本リポジトリは全ての download-artifact 利用箇所が `name:` 指定のため影響なし。

他 v5 actions (checkout / setup-java / upload-artifact) と github-script v8 は Node 20 -> 24 への runtime 更新が主で、利用方法には breaking change なし。

## Test plan

本 PR の検証は **GitHub Actions 上で全 workflow が green になること** を以て確認する (yaml の構文 validation のみローカルで完了)。

- [ ] `pull-request.yml` の全ジョブが green (ktlintCheck / apiCheck / jvmTest / jsBrowserTest / wasmJsBrowserTest / testDebugUnitTest / iosSimulatorArm64Test / integrationTest 等)
- [ ] `preview-web.yml` は main merge 後の動作確認 (Dokka / Docusaurus build + GitHub Pages deploy)
- [ ] `nightly-checking.yml` は次回 scheduled run で確認
- [ ] PR の Annotations から `actions-node20` deprecation warning が消えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)