### PR TITLE
chore(deps): bump compose-multiplatform 1.11.0-alpha01 -> rc01 (task-032)

### DIFF
--- a/.github/workflows/nightly-checking.yml
+++ b/.github/workflows/nightly-checking.yml
@@ -28,11 +28,11 @@ jobs:
             gradle_version: ''
             name: 'default'
           - kotlin_version: '2.3.21'
-            compose_version: '1.11.0-alpha04'
+            compose_version: '1.11.0-rc01'
             gradle_version: ''
             name: 'Kotlin 2.3.21'
           - kotlin_version: '2.4.0-Beta2'
-            compose_version: '1.11.0-alpha04'
+            compose_version: '1.11.0-rc01'
             gradle_version: '9.4.1'
             name: 'Kotlin 2.4.0-Beta2'
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-checking.yml
+++ b/.github/workflows/nightly-checking.yml
@@ -28,11 +28,11 @@ jobs:
             gradle_version: ''
             name: 'default'
           - kotlin_version: '2.3.21'
-            compose_version: '1.11.0-rc01'
+            compose_version: '1.11.0-alpha04'
             gradle_version: ''
             name: 'Kotlin 2.3.21'
           - kotlin_version: '2.4.0-Beta2'
-            compose_version: '1.11.0-rc01'
+            compose_version: '1.11.0-alpha04'
             gradle_version: '9.4.1'
             name: 'Kotlin 2.4.0-Beta2'
     runs-on: ubuntu-latest

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,10 +10,11 @@ jsTarget = "es2015"
 
 # Kotlin / Compose
 kotlin = "2.3.21"
-compose = "1.11.0-rc01"
-# Compose Multiplatform releases material3 on a separate cadence; keep its version in sync with the release notes.
-# https://github.com/JetBrains/compose-multiplatform/releases/tag/v1.11.0-rc01
-composeMaterial3 = "1.11.0-alpha07"
+compose = "1.11.0-alpha04"
+# Compose Multiplatform releases material3 on a separate cadence; pinned here so the
+# next compose bump does not silently move material3.
+# https://github.com/JetBrains/compose-multiplatform/releases
+composeMaterial3 = "1.11.0-alpha04"
 
 # Kotlin compiler plugin: shadow JAR bundles compat modules to support multiple Kotlin versions.
 shadow = "8.3.6"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,10 @@ jsTarget = "es2015"
 
 # Kotlin / Compose
 kotlin = "2.3.21"
-compose = "1.11.0-alpha01"
+compose = "1.11.0-rc01"
+# Compose Multiplatform releases material3 on a separate cadence; keep its version in sync with the release notes.
+# https://github.com/JetBrains/compose-multiplatform/releases/tag/v1.11.0-rc01
+composeMaterial3 = "1.11.0-alpha07"
 
 # Kotlin compiler plugin: shadow JAR bundles compat modules to support multiple Kotlin versions.
 shadow = "8.3.6"
@@ -79,7 +82,7 @@ composeUiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-previe
 composeUiTest = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "compose" }
 composeUiTestJunit4 = { module = "org.jetbrains.compose.ui:ui-test-junit4", version.ref = "compose" }
 composeComponentsResources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose" }
-composeMaterial3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "compose" }
+composeMaterial3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "composeMaterial3" }
 composeMaterialRipple = { module = "org.jetbrains.compose.material:material-ripple", version.ref = "compose" }
 
 # KotlinX Serialization


### PR DESCRIPTION
## Summary

- Resolves [`.local/ticket/task-032-compose-multiplatform-1-11-rc-lag.md`](./.local/ticket/task-032-compose-multiplatform-1-11-rc-lag.md), surfaced by Nightly Exploration [run 25697742322](https://github.com/tbsten/compose-preview-lab/actions/runs/25697742322) (P2 / cat4).
- Main project was pinned to `compose = "1.11.0-alpha01"` while JetBrains had already shipped `1.11.0-rc01`, and the nightly PBT matrix was using `1.11.0-alpha04`. Aligns both to `1.11.0-rc01`.
- Splits `material3` into its own version key (`composeMaterial3 = "1.11.0-alpha07"`) because Compose Multiplatform releases `material3` on a separate cadence; `1.11.0-rc01` of the umbrella tag pins `material3` to `1.11.0-alpha07` (verified via Maven Central: `material3-1.11.0-rc01.pom` returns 404, `material3-1.11.0-alpha07.pom` returns 200). `material-ripple` is still published at `1.11.0-rc01` so it stays on the shared `compose` key.

## Breaking changes (alpha01 -> rc01)

Reviewed [JetBrains/compose-multiplatform releases](https://github.com/JetBrains/compose-multiplatform/releases) `v1.11.0-beta01` and `v1.11.0-rc01`:

- iOS: `Dialog` and `Popup` container views are now placed on a system transition view above the root view controller but below modally presented view controllers (beta01).
- Multiple platforms: `isClearFocusOnMouseDownEnabled` flag now defaults to `false` (rc01 prerelease fix).

Neither change required source code modifications in this repo.

## Test plan

All commands executed inside this worktree:

- [x] `./gradlew jvmTest --continue` — BUILD SUCCESSFUL (2m 6s) — log: `.local/tmp/task-032-jvmtest.log`
- [x] `./gradlew :preview-lab:compileKotlinJs --continue` — BUILD SUCCESSFUL (6s)
- [x] `./gradlew :preview-lab:compileKotlinWasmJs --continue` — BUILD SUCCESSFUL (1m 30s)
- [x] `./gradlew apiCheck --continue` — BUILD SUCCESSFUL (22s) — log: `.local/tmp/task-032-apicheck.log`
- [x] `./gradlew ktlintCheck --continue` — BUILD SUCCESSFUL (4s)
- [x] `(cd integrationTest && ./gradlew jvmTest --continue)` — BUILD SUCCESSFUL (4m 31s)

Out of scope (filed as a separate ticket if needed):
- AGP bump (task-033)
- `:dev:runHot` manual smoke test (UI module unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)