### PR TITLE
chore(gradle): align wrapper to 8.14.5 across root/docs/integrationTest (task-030)

### DIFF
--- a/.github/workflows/nightly-checking.yml
+++ b/.github/workflows/nightly-checking.yml
@@ -63,7 +63,11 @@ jobs:
         if: matrix.gradle_version
         shell: bash
         run: |
+          # 3 つの独立 Gradle プロジェクト (root / docs / integrationTest) の wrapper バージョンを揃える
+          # (task-030)
           sed -i "s|gradle-.*-bin.zip|gradle-${{ matrix.gradle_version }}-bin.zip|" gradle/wrapper/gradle-wrapper.properties
+          sed -i "s|gradle-.*-bin.zip|gradle-${{ matrix.gradle_version }}-bin.zip|" docs/gradle/wrapper/gradle-wrapper.properties
+          sed -i "s|gradle-.*-bin.zip|gradle-${{ matrix.gradle_version }}-bin.zip|" integrationTest/gradle/wrapper/gradle-wrapper.properties
 
       - name: Run Library PBT
         shell: bash

--- a/.github/workflows/nightly-checking.yml
+++ b/.github/workflows/nightly-checking.yml
@@ -64,7 +64,6 @@ jobs:
         shell: bash
         run: |
           # 3 つの独立 Gradle プロジェクト (root / docs / integrationTest) の wrapper バージョンを揃える
-          # (task-030)
           sed -i "s|gradle-.*-bin.zip|gradle-${{ matrix.gradle_version }}-bin.zip|" gradle/wrapper/gradle-wrapper.properties
           sed -i "s|gradle-.*-bin.zip|gradle-${{ matrix.gradle_version }}-bin.zip|" docs/gradle/wrapper/gradle-wrapper.properties
           sed -i "s|gradle-.*-bin.zip|gradle-${{ matrix.gradle_version }}-bin.zip|" integrationTest/gradle/wrapper/gradle-wrapper.properties

--- a/docs/gradle/wrapper/gradle-wrapper.properties
+++ b/docs/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/integrationTest/gradle/wrapper/gradle-wrapper.properties
+++ b/integrationTest/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

Nightly Exploration (run [25697742322](https://github.com/tbsten/compose-preview-lab/actions/runs/25697742322)) で検出された P2 / cat2 issue ([task-030](.local/ticket/task-030-gradle-wrapper-version-drift.md)) を解消する PR。

3 つの独立 Gradle プロジェクトで wrapper バージョンが乖離していた:

| プロジェクト | 修正前 | 修正後 |
|---|---|---|
| `gradle/wrapper/gradle-wrapper.properties` | 8.13 | **8.14.5** |
| `docs/gradle/wrapper/gradle-wrapper.properties` | 8.13 | **8.14.5** |
| `integrationTest/gradle/wrapper/gradle-wrapper.properties` | 8.14.2 | **8.14.5** |

採用バージョン: **Gradle 8.14.5** (8.x 系で現時点の最新 patch、 task-033 [Gradle 9 dry-run] と整合性を保つため 8.x 安定版の最新で揃える)

## 主な変更

- 3 ファイルとも `distributionUrl` を `gradle-8.14.5-bin.zip` に統一
- `.github/workflows/nightly-checking.yml` の "Upgrade Gradle wrapper" step を 3 ファイル一括書き換えに拡張 (これまで root のみ書き換えていたため整合性が崩れる温床だった)

## Test plan

- [x] `./gradlew help --no-configuration-cache` green (root, 8.14.5 で稼働)
- [x] `(cd docs && ./gradlew help --no-configuration-cache)` green
- [x] `(cd integrationTest && ./gradlew help --no-configuration-cache)` green
- [x] `./gradlew jvmTest --continue` green
- [x] `./gradlew apiCheck --continue` green
- [x] `./gradlew ktlintCheck --continue` green
- [ ] CI 全 job 確認 (jsBrowserTest / wasmJsBrowserTest / testDebugUnitTest / iosSimulatorArm64Test / integrationTest)
- [ ] 3 つの `gradle-wrapper.properties` の `distributionUrl` が一致していることを確認 (diff 上で grep)
- [ ] `nightly-checking.yml` の sed step が 3 ファイル全てに適用されていることを確認

Related:
- task-030: Gradle wrapper version drift
- task-033: AGP/Gradle major lag (将来の 9.x 移行は別チケットで扱う)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>