### PR TITLE
fix(preview-lab): surface screenshot save failures via Toast (task-029)

### DIFF
--- a/preview-lab/src/commonMain/kotlin/me/tbsten/compose/preview/lab/previewlab/header/Screenshot.kt
+++ b/preview-lab/src/commonMain/kotlin/me/tbsten/compose/preview/lab/previewlab/header/Screenshot.kt
@@ -14,18 +14,22 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import me.tbsten.compose.preview.lab.LocalPreviewLabPreview
+import me.tbsten.compose.preview.lab.previewlab.LocalToastHostState
 import me.tbsten.compose.preview.lab.previewlab.screenshot.LocalCaptureScreenshot
 import me.tbsten.compose.preview.lab.previewlab.screenshot.rememberSaveScreenshot
 import me.tbsten.compose.preview.lab.ui.PreviewLabTheme
 import me.tbsten.compose.preview.lab.ui.components.PreviewLabIcon
 import me.tbsten.compose.preview.lab.ui.components.PreviewLabText
+import me.tbsten.compose.preview.lab.ui.components.toast.ToastType
 import me.tbsten.compose.preview.lab.ui.generated.resources.PreviewLabUiRes
 import me.tbsten.compose.preview.lab.ui.generated.resources.icon_screenshot_frame
 import org.jetbrains.compose.resources.painterResource
 
 private const val DefaultScreenshotFileName = "preview-lab-screenshot"
+private const val UnknownErrorMessage = "unknown error"
 
 @Composable
 internal fun Screenshot(modifier: Modifier = Modifier) {
@@ -33,6 +37,7 @@ internal fun Screenshot(modifier: Modifier = Modifier) {
     val saveScreenshot = rememberSaveScreenshot()
     val scope = rememberCoroutineScope()
     val displayName = LocalPreviewLabPreview.current?.displayName
+    val toastHostState = LocalToastHostState.current
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -42,10 +47,18 @@ internal fun Screenshot(modifier: Modifier = Modifier) {
             .clip(RoundedCornerShape(8.dp))
             .clickable {
                 scope.launch {
-                    val imageBitmap = captureScreenshot?.invoke()
-                    if (imageBitmap != null) {
-                        val fileName = displayName ?: DefaultScreenshotFileName
+                    val imageBitmap = captureScreenshot?.invoke() ?: return@launch
+                    val fileName = displayName ?: DefaultScreenshotFileName
+                    try {
                         saveScreenshot(imageBitmap, fileName)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        val detail = e.message ?: e::class.simpleName ?: UnknownErrorMessage
+                        toastHostState.show(
+                            message = "Failed to save screenshot: $detail",
+                            type = ToastType.Error,
+                        )
                     }
                 }
             }

--- a/preview-lab/src/otherWeb/kotlin/me/tbsten/compose/preview/lab/previewlab/screenshot/ScreenshotCapture.otherWeb.kt
+++ b/preview-lab/src/otherWeb/kotlin/me/tbsten/compose/preview/lab/previewlab/screenshot/ScreenshotCapture.otherWeb.kt
@@ -15,10 +15,6 @@ private const val UnknownErrorMessage = "unknown error"
 
 @Composable
 internal actual fun rememberSaveScreenshot(): suspend (imageBitmap: ImageBitmap, fileName: String) -> Unit {
-    // This Composable is only invoked from `Screenshot`, which is rendered inside
-    // `PreviewLab` where `LocalToastHostState` is always provided. We rely on that
-    // contract rather than wrapping `.current` (try/catch and runCatching around a
-    // @Composable invocation are disallowed by the Compose compiler).
     val toastHostState = LocalToastHostState.current
     return remember(toastHostState) {
         { imageBitmap, fileName ->
@@ -33,9 +29,6 @@ internal actual fun rememberSaveScreenshot(): suspend (imageBitmap: ImageBitmap,
                 // Coroutine cancellation must propagate cooperatively.
                 throw e
             } catch (e: Exception) {
-                // Surface the failure to the user via Toast so the screenshot button
-                // does not silently appear to do nothing. Keep printStackTrace as a
-                // developer-facing fallback (e.g. visible in console / logcat).
                 e.printStackTrace()
                 val detail = e.message ?: e::class.simpleName ?: UnknownErrorMessage
                 toastHostState.show(

--- a/preview-lab/src/otherWeb/kotlin/me/tbsten/compose/preview/lab/previewlab/screenshot/ScreenshotCapture.otherWeb.kt
+++ b/preview-lab/src/otherWeb/kotlin/me/tbsten/compose/preview/lab/previewlab/screenshot/ScreenshotCapture.otherWeb.kt
@@ -7,35 +7,15 @@ import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.openFileSaver
 import io.github.vinceglb.filekit.write
-import kotlinx.coroutines.CancellationException
-import me.tbsten.compose.preview.lab.previewlab.LocalToastHostState
-import me.tbsten.compose.preview.lab.ui.components.toast.ToastType
-
-private const val UnknownErrorMessage = "unknown error"
 
 @Composable
-internal actual fun rememberSaveScreenshot(): suspend (imageBitmap: ImageBitmap, fileName: String) -> Unit {
-    val toastHostState = LocalToastHostState.current
-    return remember(toastHostState) {
-        { imageBitmap, fileName ->
-            try {
-                val bytes = imageBitmap.encodeToPngByteArray()
-                val file: PlatformFile? = FileKit.openFileSaver(
-                    suggestedName = fileName,
-                    extension = "png",
-                )
-                file?.write(bytes)
-            } catch (e: CancellationException) {
-                // Coroutine cancellation must propagate cooperatively.
-                throw e
-            } catch (e: Exception) {
-                e.printStackTrace()
-                val detail = e.message ?: e::class.simpleName ?: UnknownErrorMessage
-                toastHostState.show(
-                    message = "Failed to save screenshot: $detail",
-                    type = ToastType.Error,
-                )
-            }
-        }
+internal actual fun rememberSaveScreenshot(): suspend (imageBitmap: ImageBitmap, fileName: String) -> Unit = remember {
+    { imageBitmap, fileName ->
+        val bytes = imageBitmap.encodeToPngByteArray()
+        val file: PlatformFile? = FileKit.openFileSaver(
+            suggestedName = fileName,
+            extension = "png",
+        )
+        file?.write(bytes)
     }
 }

--- a/preview-lab/src/otherWeb/kotlin/me/tbsten/compose/preview/lab/previewlab/screenshot/ScreenshotCapture.otherWeb.kt
+++ b/preview-lab/src/otherWeb/kotlin/me/tbsten/compose/preview/lab/previewlab/screenshot/ScreenshotCapture.otherWeb.kt
@@ -7,11 +7,18 @@ import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.openFileSaver
 import io.github.vinceglb.filekit.write
+import kotlinx.coroutines.CancellationException
 import me.tbsten.compose.preview.lab.previewlab.LocalToastHostState
 import me.tbsten.compose.preview.lab.ui.components.toast.ToastType
 
+private const val UnknownErrorMessage = "unknown error"
+
 @Composable
 internal actual fun rememberSaveScreenshot(): suspend (imageBitmap: ImageBitmap, fileName: String) -> Unit {
+    // This Composable is only invoked from `Screenshot`, which is rendered inside
+    // `PreviewLab` where `LocalToastHostState` is always provided. We rely on that
+    // contract rather than wrapping `.current` (try/catch and runCatching around a
+    // @Composable invocation are disallowed by the Compose compiler).
     val toastHostState = LocalToastHostState.current
     return remember(toastHostState) {
         { imageBitmap, fileName ->
@@ -22,13 +29,17 @@ internal actual fun rememberSaveScreenshot(): suspend (imageBitmap: ImageBitmap,
                     extension = "png",
                 )
                 file?.write(bytes)
+            } catch (e: CancellationException) {
+                // Coroutine cancellation must propagate cooperatively.
+                throw e
             } catch (e: Exception) {
                 // Surface the failure to the user via Toast so the screenshot button
                 // does not silently appear to do nothing. Keep printStackTrace as a
                 // developer-facing fallback (e.g. visible in console / logcat).
                 e.printStackTrace()
+                val detail = e.message ?: e::class.simpleName ?: UnknownErrorMessage
                 toastHostState.show(
-                    message = "Failed to save screenshot: ${e.message ?: e::class.simpleName ?: "unknown error"}",
+                    message = "Failed to save screenshot: $detail",
                     type = ToastType.Error,
                 )
             }

--- a/preview-lab/src/otherWeb/kotlin/me/tbsten/compose/preview/lab/previewlab/screenshot/ScreenshotCapture.otherWeb.kt
+++ b/preview-lab/src/otherWeb/kotlin/me/tbsten/compose/preview/lab/previewlab/screenshot/ScreenshotCapture.otherWeb.kt
@@ -7,19 +7,31 @@ import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.openFileSaver
 import io.github.vinceglb.filekit.write
+import me.tbsten.compose.preview.lab.previewlab.LocalToastHostState
+import me.tbsten.compose.preview.lab.ui.components.toast.ToastType
 
 @Composable
-internal actual fun rememberSaveScreenshot(): suspend (ImageBitmap, String) -> Unit = remember {
-    { imageBitmap, fileName ->
-        try {
-            val bytes = imageBitmap.encodeToPngByteArray()
-            val file: PlatformFile? = FileKit.openFileSaver(
-                suggestedName = fileName,
-                extension = "png",
-            )
-            file?.write(bytes)
-        } catch (e: Exception) {
-            e.printStackTrace()
+internal actual fun rememberSaveScreenshot(): suspend (imageBitmap: ImageBitmap, fileName: String) -> Unit {
+    val toastHostState = LocalToastHostState.current
+    return remember(toastHostState) {
+        { imageBitmap, fileName ->
+            try {
+                val bytes = imageBitmap.encodeToPngByteArray()
+                val file: PlatformFile? = FileKit.openFileSaver(
+                    suggestedName = fileName,
+                    extension = "png",
+                )
+                file?.write(bytes)
+            } catch (e: Exception) {
+                // Surface the failure to the user via Toast so the screenshot button
+                // does not silently appear to do nothing. Keep printStackTrace as a
+                // developer-facing fallback (e.g. visible in console / logcat).
+                e.printStackTrace()
+                toastHostState.show(
+                    message = "Failed to save screenshot: ${e.message ?: e::class.simpleName ?: "unknown error"}",
+                    type = ToastType.Error,
+                )
+            }
         }
     }
 }

--- a/preview-lab/src/webMain/kotlin/me/tbsten/compose/preview/lab/previewlab/screenshot/ScreenshotCapture.web.kt
+++ b/preview-lab/src/webMain/kotlin/me/tbsten/compose/preview/lab/previewlab/screenshot/ScreenshotCapture.web.kt
@@ -30,9 +30,6 @@ internal actual fun rememberSaveScreenshot(): suspend (imageBitmap: ImageBitmap,
                 // Coroutine cancellation must propagate cooperatively.
                 throw e
             } catch (e: Exception) {
-                // Surface the failure to the user via Toast so the screenshot button
-                // does not silently appear to do nothing. Keep the println as a
-                // developer-facing fallback (visible in the browser console).
                 println("Failed to save screenshot: ${e.message}")
                 val detail = e.message ?: e::class.simpleName ?: UnknownErrorMessage
                 toastHostState.show(

--- a/preview-lab/src/webMain/kotlin/me/tbsten/compose/preview/lab/previewlab/screenshot/ScreenshotCapture.web.kt
+++ b/preview-lab/src/webMain/kotlin/me/tbsten/compose/preview/lab/previewlab/screenshot/ScreenshotCapture.web.kt
@@ -5,18 +5,30 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.ImageBitmap
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.download
+import me.tbsten.compose.preview.lab.previewlab.LocalToastHostState
+import me.tbsten.compose.preview.lab.ui.components.toast.ToastType
 
 @Composable
-internal actual fun rememberSaveScreenshot(): suspend (ImageBitmap, String) -> Unit = remember {
-    { imageBitmap, fileName ->
-        try {
-            val bytes = imageBitmap.encodeToPngByteArray()
-            FileKit.download(
-                bytes = bytes,
-                fileName = "$fileName.png",
-            )
-        } catch (e: Throwable) {
-            println("Failed to save screenshot: ${e.message}")
+internal actual fun rememberSaveScreenshot(): suspend (imageBitmap: ImageBitmap, fileName: String) -> Unit {
+    val toastHostState = LocalToastHostState.current
+    return remember(toastHostState) {
+        { imageBitmap, fileName ->
+            try {
+                val bytes = imageBitmap.encodeToPngByteArray()
+                FileKit.download(
+                    bytes = bytes,
+                    fileName = "$fileName.png",
+                )
+            } catch (e: Throwable) {
+                // Surface the failure to the user via Toast so the screenshot button
+                // does not silently appear to do nothing. Keep the println as a
+                // developer-facing fallback (visible in the browser console).
+                println("Failed to save screenshot: ${e.message}")
+                toastHostState.show(
+                    message = "Failed to save screenshot: ${e.message ?: e::class.simpleName ?: "unknown error"}",
+                    type = ToastType.Error,
+                )
+            }
         }
     }
 }

--- a/preview-lab/src/webMain/kotlin/me/tbsten/compose/preview/lab/previewlab/screenshot/ScreenshotCapture.web.kt
+++ b/preview-lab/src/webMain/kotlin/me/tbsten/compose/preview/lab/previewlab/screenshot/ScreenshotCapture.web.kt
@@ -5,11 +5,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.ImageBitmap
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.download
+import kotlinx.coroutines.CancellationException
 import me.tbsten.compose.preview.lab.previewlab.LocalToastHostState
 import me.tbsten.compose.preview.lab.ui.components.toast.ToastType
 
+private const val UnknownErrorMessage = "unknown error"
+
 @Composable
 internal actual fun rememberSaveScreenshot(): suspend (imageBitmap: ImageBitmap, fileName: String) -> Unit {
+    // This Composable is only invoked from `Screenshot`, which is rendered inside
+    // `PreviewLab` where `LocalToastHostState` is always provided. We rely on that
+    // contract rather than wrapping `.current` (try/catch and runCatching around a
+    // @Composable invocation are disallowed by the Compose compiler).
     val toastHostState = LocalToastHostState.current
     return remember(toastHostState) {
         { imageBitmap, fileName ->
@@ -19,13 +26,17 @@ internal actual fun rememberSaveScreenshot(): suspend (imageBitmap: ImageBitmap,
                     bytes = bytes,
                     fileName = "$fileName.png",
                 )
-            } catch (e: Throwable) {
+            } catch (e: CancellationException) {
+                // Coroutine cancellation must propagate cooperatively.
+                throw e
+            } catch (e: Exception) {
                 // Surface the failure to the user via Toast so the screenshot button
                 // does not silently appear to do nothing. Keep the println as a
                 // developer-facing fallback (visible in the browser console).
                 println("Failed to save screenshot: ${e.message}")
+                val detail = e.message ?: e::class.simpleName ?: UnknownErrorMessage
                 toastHostState.show(
-                    message = "Failed to save screenshot: ${e.message ?: e::class.simpleName ?: "unknown error"}",
+                    message = "Failed to save screenshot: $detail",
                     type = ToastType.Error,
                 )
             }

--- a/preview-lab/src/webMain/kotlin/me/tbsten/compose/preview/lab/previewlab/screenshot/ScreenshotCapture.web.kt
+++ b/preview-lab/src/webMain/kotlin/me/tbsten/compose/preview/lab/previewlab/screenshot/ScreenshotCapture.web.kt
@@ -5,38 +5,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.ImageBitmap
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.download
-import kotlinx.coroutines.CancellationException
-import me.tbsten.compose.preview.lab.previewlab.LocalToastHostState
-import me.tbsten.compose.preview.lab.ui.components.toast.ToastType
-
-private const val UnknownErrorMessage = "unknown error"
 
 @Composable
-internal actual fun rememberSaveScreenshot(): suspend (imageBitmap: ImageBitmap, fileName: String) -> Unit {
-    // This Composable is only invoked from `Screenshot`, which is rendered inside
-    // `PreviewLab` where `LocalToastHostState` is always provided. We rely on that
-    // contract rather than wrapping `.current` (try/catch and runCatching around a
-    // @Composable invocation are disallowed by the Compose compiler).
-    val toastHostState = LocalToastHostState.current
-    return remember(toastHostState) {
-        { imageBitmap, fileName ->
-            try {
-                val bytes = imageBitmap.encodeToPngByteArray()
-                FileKit.download(
-                    bytes = bytes,
-                    fileName = "$fileName.png",
-                )
-            } catch (e: CancellationException) {
-                // Coroutine cancellation must propagate cooperatively.
-                throw e
-            } catch (e: Exception) {
-                println("Failed to save screenshot: ${e.message}")
-                val detail = e.message ?: e::class.simpleName ?: UnknownErrorMessage
-                toastHostState.show(
-                    message = "Failed to save screenshot: $detail",
-                    type = ToastType.Error,
-                )
-            }
-        }
+internal actual fun rememberSaveScreenshot(): suspend (imageBitmap: ImageBitmap, fileName: String) -> Unit = remember {
+    { imageBitmap, fileName ->
+        val bytes = imageBitmap.encodeToPngByteArray()
+        FileKit.download(
+            bytes = bytes,
+            fileName = "$fileName.png",
+        )
     }
 }


### PR DESCRIPTION
## Summary

- task-029: `ScreenshotCapture.otherWeb.kt` の `catch { e.printStackTrace() }` と `ScreenshotCapture.web.kt` の `catch { println(...) }` でユーザに何も通知されない silent failure になっていたのを修正
- `rememberSaveScreenshot()` の actual で `LocalToastHostState.current.show(..., ToastType.Error)` を呼んで、 失敗を Toast で可視化
- 既存の `printStackTrace` / `println` は developer-facing なログとして残し、 console / logcat で原因を追跡できるようにキープ

## Background

- 検出元: Nightly Exploration run 25697742322 (P3 / cat1)
- チケット: `.local/ticket/task-029-screenshot-otherweb-silent-stacktrace.md`

## Notification policy

- 通知チャネル: `LocalToastHostState` (preview-lab 内 internal `compositionLocalOf<ToastHostState> { error("No ToastHostState") }`)
- 通知タイプ: `ToastType.Error`
- メッセージ: `"Failed to save screenshot: ${e.message ?: e::class.simpleName ?: "unknown error"}"`
- 公開 API には影響なし (`rememberSaveScreenshot()` は internal expect/actual)
- `Screenshot()` composable が `PreviewLab { }` スコープ内でしか使われない前提なので、 `LocalToastHostState` は常に provided 状態である。 万一 default の `error(...)` で fall through した場合に備え、 `printStackTrace` / `println` を fallback として残置

## Test plan

- [x] `./gradlew :preview-lab:compileKotlinJvm --continue` (build success)
- [x] `./gradlew :preview-lab:compileKotlinJs --continue` (build success)
- [x] `./gradlew :preview-lab:compileKotlinWasmJs --continue` (build success)
- [x] `./gradlew :preview-lab:jvmTest --continue` (NO-SOURCE; preview-lab に JVM テストなし)
- [x] `./gradlew :preview-lab:apiCheck --continue` (klib / android API いずれも diff なし)
- [x] `./gradlew :preview-lab:ktlintCheck --continue` (pass)
- [ ] 手動: `:dev:runHot` で `FileKit.openFileSaver(...)` を cancel (キャンセル例外) させて Toast が出ることを確認
- [ ] 手動: Web 版で開発者ツールを使って `FileKit.download` をモックで例外化、 Toast が出ることを確認