### PR TITLE
fix(core): unify WarnDuplicatePreview prefix and warning level across platforms (task-037)

### DIFF
--- a/core/src/androidMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.android.kt
+++ b/core/src/androidMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.android.kt
@@ -6,11 +6,5 @@ private const val TAG: String = "ComposePreviewLab"
 
 @InternalComposePreviewLabApi
 public actual fun warnDuplicatePreview(message: String) {
-    // `Log.w` routes through Logcat's WARN severity so Android Studio colors/filters
-    // the line as a warning. The Logcat tag (`"ComposePreviewLab"`) already provides
-    // a per-line filter; we additionally prepend the shared [WarnPrefix] so the body
-    // is grep-identical to the other platforms (JVM / iOS / JS / Wasm JS), allowing
-    // log-collectors configured against `"[ComposePreviewLab WARN] "` to match here
-    // too.
     Log.w(TAG, "$WarnPrefix$message")
 }

--- a/core/src/androidMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.android.kt
+++ b/core/src/androidMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.android.kt
@@ -6,5 +6,11 @@ private const val TAG: String = "ComposePreviewLab"
 
 @InternalComposePreviewLabApi
 public actual fun warnDuplicatePreview(message: String) {
-    Log.w(TAG, message)
+    // `Log.w` routes through Logcat's WARN severity so Android Studio colors/filters
+    // the line as a warning. The Logcat tag (`"ComposePreviewLab"`) already provides
+    // a per-line filter; we additionally prepend the shared [WarnPrefix] so the body
+    // is grep-identical to the other platforms (JVM / iOS / JS / Wasm JS), allowing
+    // log-collectors configured against `"[ComposePreviewLab WARN] "` to match here
+    // too.
+    Log.w(TAG, "$WarnPrefix$message")
 }

--- a/core/src/commonMain/kotlin/me/tbsten/compose/preview/lab/CollectModulePreviews.kt
+++ b/core/src/commonMain/kotlin/me/tbsten/compose/preview/lab/CollectModulePreviews.kt
@@ -230,11 +230,13 @@ public fun collectAllModulePreviews(scope: String): ReadOnlyProperty<Any?, Seque
  * silently lost. The runtime can detect this only by observing duplicate
  * `CollectedPreview.id` values reaching this aggregator, which is rare because the
  * same FQN collapse already eliminated one of them upstream. We surface those
- * duplicates via [warnDuplicatePreview], which routes per platform: JVM / Android /
- * iOS keep the existing stdout behavior so build / test logs continue to surface the
- * warning, while JS / Wasm JS write via `console.warn` so the warning lights up in
- * browser DevTools (yellow highlighting) and survives headless test runners that
- * filter `console.log`.
+ * duplicates via [warnDuplicatePreview], which routes per platform to each target's
+ * dedicated warning surface: JVM writes to `System.err`, Android uses `Log.w`, iOS
+ * uses `NSLog`, and JS / Wasm JS use `console.warn` (yellow-highlighted in browser
+ * DevTools and surfaced separately from `console.log` by headless test runners that
+ * filter by severity). Every actual prepends the shared `WarnPrefix`
+ * (`"[ComposePreviewLab WARN] "`) so log-collector filters configured against that
+ * literal match every platform's emission.
  *
  * The compiler plugin also attempts a best-effort compile-time warning when its symbol
  * scan returns duplicate hints (in `HintDiscovery.discoverHints`, which lives in the
@@ -276,9 +278,9 @@ public fun distinctPreviewsById(previews: List<CollectedPreview>): List<Collecte
             dupCounts[preview.id] = if (existing == null) 2 else existing + 1
         }
     }
-    // [warnDuplicatePreview] routes per platform — stdout on JVM / Android / iOS,
-    // `console.warn` on JS / Wasm JS — so the warning is visible in the medium where
-    // users most often look for runtime signals on each target. The warning fires
+    // [warnDuplicatePreview] routes per platform to each target's warning surface
+    // (`System.err` on JVM, `Log.w` on Android, `NSLog` on iOS, `console.warn` on
+    // JS / Wasm JS), all prepended with the shared `WarnPrefix`. The warning fires
     // once per app launch even if the duplicated preview is never displayed, so users
     // see it during dev iteration.
     for ((id, count) in dupCounts) {
@@ -303,16 +305,16 @@ public fun distinctPreviewsById(previews: List<CollectedPreview>): List<Collecte
  * Sequence-shaped variant of [distinctPreviewsById] used by the compiler plugin's
  * `collectAllModulePreviews()` IR rewrite. Walks [previews] once, yields each first
  * occurrence by [CollectedPreview.id] in encounter order, and on the final
- * `next() == null` step prints one stdout warning per id that collided two-or-more
- * times.
+ * `next() == null` step emits one [warnDuplicatePreview] line per id that collided
+ * two-or-more times.
  *
  * The behavior matches [distinctPreviewsById] except the fold is lazy: an early-exit
  * consumer (`previews.firstOrNull { ... }`, `previews.take(2)`) only iterates the
  * prefix it needs, and dup detection runs only over that prefix. A consumer that
  * drains the sequence via `previews.toList()` sees the full warning set, identical
  * to the pre-laziness behavior — and uses the per-platform [warnDuplicatePreview]
- * routing so JS / Wasm JS surface the warning via `console.warn` rather than
- * `console.log`.
+ * routing (`System.err` on JVM, `Log.w` on Android, `NSLog` on iOS, `console.warn`
+ * on JS / Wasm JS) with the shared `WarnPrefix` prepended.
  *
  * Internal API — meant only as a callsite for the compiler plugin.
  */

--- a/core/src/commonMain/kotlin/me/tbsten/compose/preview/lab/CollectModulePreviews.kt
+++ b/core/src/commonMain/kotlin/me/tbsten/compose/preview/lab/CollectModulePreviews.kt
@@ -285,7 +285,7 @@ public fun distinctPreviewsById(previews: List<CollectedPreview>): List<Collecte
     // see it during dev iteration.
     for ((id, count) in dupCounts) {
         warnDuplicatePreview(
-            "[ComposePreviewLab] WARNING: $count `CollectedPreview` entries share " +
+            "$count `CollectedPreview` entries share " +
                 "id=\"$id\". Likely cause: a `@Preview` with the same fully-qualified name " +
                 "is declared in two or more dependency artifacts on the classpath, so their " +
                 "marker / hint classes collide and only one survives — the other preview's " +
@@ -332,7 +332,7 @@ public fun distinctPreviewsByIdSequence(previews: Sequence<CollectedPreview>): S
     }
     for ((id, count) in dupCounts) {
         warnDuplicatePreview(
-            "[ComposePreviewLab] WARNING: $count `CollectedPreview` entries share " +
+            "$count `CollectedPreview` entries share " +
                 "id=\"$id\". Likely cause: a `@Preview` with the same fully-qualified name " +
                 "is declared in two or more dependency artifacts on the classpath, so their " +
                 "marker / hint classes collide and only one survives — the other preview's " +

--- a/core/src/commonMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.kt
+++ b/core/src/commonMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.kt
@@ -1,22 +1,40 @@
 package me.tbsten.compose.preview.lab
 
 /**
+ * Single source of truth prefix prepended by every [warnDuplicatePreview] actual
+ * before the message body is emitted to the platform's warning surface.
+ *
+ * Keeping the prefix in `commonMain` ensures that grep / log-collector filters
+ * configured against this exact literal keep working regardless of which platform
+ * actually produced the line — JVM (`System.err`), Android (`Log.w`), iOS (`NSLog`)
+ * and JS / Wasm JS (`console.warn`) all emit the same `"[ComposePreviewLab WARN] "`
+ * prefix. The prefix is intentionally `internal const`: it is implementation detail
+ * shared between the actual files, not part of the consumer-facing API.
+ */
+internal const val WarnPrefix: String = "[ComposePreviewLab WARN] "
+
+/**
  * Emits a warning about duplicate preview ids to the platform's most discoverable
- * surface. Used internally by [distinctPreviewsById] to surface cross-artifact same-FQN
- * preview collisions; not part of the consumer-facing API.
+ * warning surface. Used internally by [distinctPreviewsById] to surface cross-artifact
+ * same-FQN preview collisions; not part of the consumer-facing API.
  *
  * **Per-platform routing**:
- * - JVM / Android / iOS: stdout (`println`) — matches the historical behavior so existing
- *   build / test logs keep showing the warning.
- * - JS / Wasm JS: `console.warn` so the warning lights up in the browser DevTools (yellow
- *   highlighting) and ends up in CI runners that surface `console.warn` separately from
- *   `console.log`. Without this routing the warning was emitted via stdlib `println` →
- *   `console.log`, which is invisible to a user who has not opened DevTools and is also
- *   filtered by some headless test runners. See the corresponding KDoc on
- *   [distinctPreviewsById] for the broader visibility note.
+ * - JVM: `System.err.println` — keeps the warning out of stdout (where build logs are
+ *   parsed by tooling) and onto the standard error stream that IDEs / CI surfaces
+ *   highlight separately.
+ * - Android: `Log.w("ComposePreviewLab", ...)` — picks up Logcat's warning severity
+ *   filter so the line is colored / level-tagged in Android Studio.
+ * - iOS: `NSLog` — routes through the unified logging system so the line shows up in
+ *   Xcode console and Console.app.
+ * - JS / Wasm JS: `console.warn` — yellow-highlighted in browser DevTools and
+ *   surfaced separately from `console.log` by headless test runners that filter logs
+ *   by severity.
  *
- * `commonMain` has no portable stderr API across all CMP targets — `expect/actual` is the
- * only way to route per-platform without dragging in a logging framework.
+ * All actuals prepend the shared [WarnPrefix] before [message] so callers and log
+ * collectors can rely on a single literal across every platform.
+ *
+ * `commonMain` has no portable warning API across all CMP targets — `expect/actual` is
+ * the only way to route per-platform without dragging in a logging framework.
  */
 @InternalComposePreviewLabApi
 public expect fun warnDuplicatePreview(message: String)

--- a/core/src/iosMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.ios.kt
+++ b/core/src/iosMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.ios.kt
@@ -7,15 +7,5 @@ import platform.Foundation.NSLog
 
 @InternalComposePreviewLabApi
 public actual fun warnDuplicatePreview(message: String) {
-    // The format string is the fixed literal `"%@%@"` — it contains no embedded data,
-    // so it cannot be turned into a printf-format-injection vector regardless of how
-    // `WarnPrefix` or `message` evolve in the future. Both `WarnPrefix` (a `commonMain`
-    // constant such as `"[ComposePreviewLab WARN] "`) and the user-supplied `message`
-    // are passed as separate NSString arguments and consumed by the two `%@` specifiers
-    // verbatim, so any `%`-prefixed sequences inside either value are rendered as
-    // literal characters rather than re-interpreted as format directives. The default
-    // NSLog severity is what Apple's tooling treats as "default"; the `WarnPrefix`
-    // makes the line stand out in Xcode console / Console.app and keeps the body
-    // identical to every other platform's emission for grep / log-collector filters.
     NSLog("%@%@", WarnPrefix as Any, message as Any)
 }

--- a/core/src/iosMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.ios.kt
+++ b/core/src/iosMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.ios.kt
@@ -7,15 +7,15 @@ import platform.Foundation.NSLog
 
 @InternalComposePreviewLabApi
 public actual fun warnDuplicatePreview(message: String) {
-    // The format string is `"$WarnPrefix%@"` — `WarnPrefix` is a `commonMain` literal
-    // (`"[ComposePreviewLab WARN] "`) that contains no `%` characters, so it can be
-    // safely concatenated into the NSLog format string without changing printf parsing.
-    // `%@` is the only format specifier, and the user-supplied `message` is passed as
-    // the corresponding NSString argument — so even if `message` contains `%`-prefixed
-    // sequences, NSLog formats them as literal characters rather than consuming them.
-    // The default NSLog severity is what Apple's tooling treats as "default"; the
-    // `WarnPrefix` makes the line stand out in Xcode console / Console.app and keeps
-    // the body identical to every other platform's emission for grep / log-collector
-    // filters.
-    NSLog("$WarnPrefix%@", message as Any)
+    // The format string is the fixed literal `"%@%@"` — it contains no embedded data,
+    // so it cannot be turned into a printf-format-injection vector regardless of how
+    // `WarnPrefix` or `message` evolve in the future. Both `WarnPrefix` (a `commonMain`
+    // constant such as `"[ComposePreviewLab WARN] "`) and the user-supplied `message`
+    // are passed as separate NSString arguments and consumed by the two `%@` specifiers
+    // verbatim, so any `%`-prefixed sequences inside either value are rendered as
+    // literal characters rather than re-interpreted as format directives. The default
+    // NSLog severity is what Apple's tooling treats as "default"; the `WarnPrefix`
+    // makes the line stand out in Xcode console / Console.app and keeps the body
+    // identical to every other platform's emission for grep / log-collector filters.
+    NSLog("%@%@", WarnPrefix as Any, message as Any)
 }

--- a/core/src/iosMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.ios.kt
+++ b/core/src/iosMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.ios.kt
@@ -7,10 +7,15 @@ import platform.Foundation.NSLog
 
 @InternalComposePreviewLabApi
 public actual fun warnDuplicatePreview(message: String) {
-    // `NSLog("%@", ...)` formats the message as an NSString without consuming any
-    // `%`-prefixed sequences inside the body — `%@` is the only specifier in the
-    // format string, so printf-style injection from user-supplied content is safe.
-    // The default NSLog severity level is what Apple's tooling treats as "default";
-    // we prefix with `[WARN]` so the line stands out in Xcode console / Console.app.
-    NSLog("[ComposePreviewLab WARN] %@", message as Any)
+    // The format string is `"$WarnPrefix%@"` — `WarnPrefix` is a `commonMain` literal
+    // (`"[ComposePreviewLab WARN] "`) that contains no `%` characters, so it can be
+    // safely concatenated into the NSLog format string without changing printf parsing.
+    // `%@` is the only format specifier, and the user-supplied `message` is passed as
+    // the corresponding NSString argument — so even if `message` contains `%`-prefixed
+    // sequences, NSLog formats them as literal characters rather than consuming them.
+    // The default NSLog severity is what Apple's tooling treats as "default"; the
+    // `WarnPrefix` makes the line stand out in Xcode console / Console.app and keeps
+    // the body identical to every other platform's emission for grep / log-collector
+    // filters.
+    NSLog("$WarnPrefix%@", message as Any)
 }

--- a/core/src/jsMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.js.kt
+++ b/core/src/jsMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.js.kt
@@ -4,9 +4,5 @@ import kotlin.js.console
 
 @InternalComposePreviewLabApi
 public actual fun warnDuplicatePreview(message: String) {
-    // The shared [WarnPrefix] is prepended so the emitted line is byte-identical to
-    // the other platforms' output. `console.warn` shows as yellow in browser DevTools
-    // and is surfaced separately from `console.log` by headless test runners that
-    // filter by severity.
     console.warn("$WarnPrefix$message")
 }

--- a/core/src/jsMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.js.kt
+++ b/core/src/jsMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.js.kt
@@ -4,5 +4,9 @@ import kotlin.js.console
 
 @InternalComposePreviewLabApi
 public actual fun warnDuplicatePreview(message: String) {
-    console.warn(message)
+    // The shared [WarnPrefix] is prepended so the emitted line is byte-identical to
+    // the other platforms' output. `console.warn` shows as yellow in browser DevTools
+    // and is surfaced separately from `console.log` by headless test runners that
+    // filter by severity.
+    console.warn("$WarnPrefix$message")
 }

--- a/core/src/jvmMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.jvm.kt
+++ b/core/src/jvmMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.jvm.kt
@@ -2,10 +2,5 @@ package me.tbsten.compose.preview.lab
 
 @InternalComposePreviewLabApi
 public actual fun warnDuplicatePreview(message: String) {
-    // `System.err` (vs `println` / `System.out`) keeps the warning off stdout — which
-    // build/test runners parse for structured output — and onto the dedicated error
-    // stream that IDEs and CI surfaces highlight separately. The shared [WarnPrefix]
-    // is prepended so log-collector filters configured against the literal prefix
-    // match identical lines across every platform.
     System.err.println("$WarnPrefix$message")
 }

--- a/core/src/jvmMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.jvm.kt
+++ b/core/src/jvmMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.jvm.kt
@@ -2,5 +2,10 @@ package me.tbsten.compose.preview.lab
 
 @InternalComposePreviewLabApi
 public actual fun warnDuplicatePreview(message: String) {
-    println(message)
+    // `System.err` (vs `println` / `System.out`) keeps the warning off stdout — which
+    // build/test runners parse for structured output — and onto the dedicated error
+    // stream that IDEs and CI surfaces highlight separately. The shared [WarnPrefix]
+    // is prepended so log-collector filters configured against the literal prefix
+    // match identical lines across every platform.
+    System.err.println("$WarnPrefix$message")
 }

--- a/core/src/wasmJsMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.wasmJs.kt
+++ b/core/src/wasmJsMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.wasmJs.kt
@@ -17,9 +17,5 @@ private external fun consoleWarn(message: String)
 
 @InternalComposePreviewLabApi
 public actual fun warnDuplicatePreview(message: String) {
-    // The shared [WarnPrefix] is prepended in Kotlin (rather than baked into the
-    // `@JsFun` body) so the prefix stays the single source of truth in `commonMain`
-    // and so the Kotlin-level concatenation goes through normal string handling
-    // rather than the JS-side parameter marshalling.
     consoleWarn("$WarnPrefix$message")
 }

--- a/core/src/wasmJsMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.wasmJs.kt
+++ b/core/src/wasmJsMain/kotlin/me/tbsten/compose/preview/lab/WarnDuplicatePreview.wasmJs.kt
@@ -17,5 +17,9 @@ private external fun consoleWarn(message: String)
 
 @InternalComposePreviewLabApi
 public actual fun warnDuplicatePreview(message: String) {
-    consoleWarn(message)
+    // The shared [WarnPrefix] is prepended in Kotlin (rather than baked into the
+    // `@JsFun` body) so the prefix stays the single source of truth in `commonMain`
+    // and so the Kotlin-level concatenation goes through normal string handling
+    // rather than the JS-side parameter marshalling.
+    consoleWarn("$WarnPrefix$message")
 }


### PR DESCRIPTION
## Summary

Resolves `.local/ticket/task-037-warnduplicatepreview-jvm-inconsistent.md`, detected by Nightly Exploration run [25697742322](https://github.com/tbsten/compose-preview-lab/actions/runs/25697742322).

`core/src/jvmMain/.../WarnDuplicatePreview.jvm.kt` used `println(message)` which emitted the duplicate-preview signal to **stdout with no prefix** — inconsistent with every other target:

| target  | before                                                | after                                           |
| ------- | ----------------------------------------------------- | ----------------------------------------------- |
| JVM     | `println(message)` (stdout, no prefix)                | `System.err.println("$WarnPrefix$message")`     |
| Android | `Log.w("ComposePreviewLab", message)`                 | `Log.w("ComposePreviewLab", "$WarnPrefix$message")` |
| iOS     | `NSLog("[ComposePreviewLab WARN] %@", message)`       | `NSLog("$WarnPrefix%@", message)` (same prefix, now SoT) |
| JS      | `console.warn(message)`                               | `console.warn("$WarnPrefix$message")`           |
| Wasm JS | `consoleWarn(message)`                                | `consoleWarn("$WarnPrefix$message")`            |

`internal const val WarnPrefix = "[ComposePreviewLab WARN] "` is added to `commonMain/WarnDuplicatePreview.kt` as the single source of truth, so log-collector filters configured against that literal match every platform's emission. Public API is unchanged (the prefix is `internal`; the function is still annotated `@InternalComposePreviewLabApi`). KDoc on `distinctPreviewsById` / `distinctPreviewsByIdSequence` is refreshed to describe the new per-platform routing.

## Test plan

- [x] `./gradlew :core:compileKotlinJvm --continue`
- [x] `./gradlew :core:compileReleaseKotlinAndroid --continue`
- [x] `./gradlew :core:compileKotlinJs --continue`
- [x] `./gradlew :core:compileKotlinWasmJs --continue`
- [x] `./gradlew :core:compileKotlinIosSimulatorArm64 --continue`
- [x] `./gradlew :core:apiCheck --continue` (internal const → no public API change)
- [x] `./gradlew :core:ktlintCheck --continue`
- [x] `./gradlew jvmTest -Dkotest.tags='!PBT' --continue` (all modules green)
- [ ] CI green on all platforms