### PR TITLE
chore(gradle-plugin): silence kotlin-dsl version mismatch warning (task-034)

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -14,7 +14,9 @@ plugins {
 // Gradle 9 系で embedded Kotlin が更新されれば消える想定だが (task-033 と連動)、それまでの短期 mitigation として
 // `kotlin-dsl` plugin を `org.jetbrains.kotlin.jvm` + `java-gradle-plugin` に分解する。
 // 本ファイルは precompiled `.gradle.kts` を含まないため `kotlin-dsl` 固有機能には依存していない。
-// `gradleApi()` 経由で Gradle Kotlin DSL API は引き続き利用可能。
+// Gradle Kotlin DSL の拡張 (`getByType<>()` / `register<>()` 等) は `gradleApi()` ではなく
+// `gradleKotlinDsl()` が提供するため、下の dependencies ブロックで `compileOnly(gradleKotlinDsl())`
+// として明示的に追加している。 `gradleKotlinDsl()` を外すと src/ 配下の Kotlin DSL 拡張が解決できなくなる。
 
 kotlin {
     jvmToolchain(libs.versions.jvmToolchain.get().toInt())

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -4,12 +4,18 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     alias(libs.plugins.conventionFormat)
     alias(libs.plugins.conventionPublish)
-    `kotlin-dsl`
+    alias(libs.plugins.kotlinJvm)
+    `java-gradle-plugin`
 }
 
-// kotlin-dsl が提供する embedded Kotlin を使うため、
-// conventionJvm (libs の kotlinJvm を明示的に適用する) は付与しない。
-// conventionJvm が提供していた toolchain / opt-ins 設定を手動で行う。
+// task-034: Gradle 8.13 同梱の `kotlin-dsl` plugin は embedded Kotlin (2.0.21) を要求するが、
+// 本プロジェクトは Kotlin 2.3.21 を使うため毎ビルド `WARNING: Unsupported Kotlin plugin version.`
+// が `:gradle-plugin` の Configure フェーズで出てしまう。
+// Gradle 9 系で embedded Kotlin が更新されれば消える想定だが (task-033 と連動)、それまでの短期 mitigation として
+// `kotlin-dsl` plugin を `org.jetbrains.kotlin.jvm` + `java-gradle-plugin` に分解する。
+// 本ファイルは precompiled `.gradle.kts` を含まないため `kotlin-dsl` 固有機能には依存していない。
+// `gradleApi()` 経由で Gradle Kotlin DSL API は引き続き利用可能。
+
 kotlin {
     jvmToolchain(libs.versions.jvmToolchain.get().toInt())
     compilerOptions {
@@ -21,11 +27,8 @@ kotlin {
     }
 }
 
-// kotlin-dsl は language/api version を 1.8 に固定するが、
-// Kotlin 2.3+ では 1.8 が廃止されているため明示的に 2.1 以上に上書きする。
-// kotlin.compilerOptions では kotlin-dsl の afterEvaluate 設定を
-// 上書きできないため、task 単位で設定する。
-// https://kotl.in/gradle/kotlin-dsl-version-compatibility
+// Kotlin compile task の language/api version を embedded と歩調を合わせる目的ではなく、
+// プロジェクト全体で使う Kotlin 機能の互換 floor を 2.1 に固定する。
 tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
         apiVersion.set(KotlinVersion.KOTLIN_2_1)
@@ -61,6 +64,10 @@ kotlin.sourceSets.named("main") {
 dependencies {
     api(projects.annotation)
     compileOnly(gradleApi())
+    // task-034: `kotlin-dsl` plugin が自動で追加していた Gradle Kotlin DSL API を手動で復元。
+    // build script 本体は precompiled script plugin を含まないが、src/ 配下の Kotlin code は
+    // `getByType<>()`, `register<>()`, ExtensionAware.property delegate などの拡張関数を利用する。
+    compileOnly(gradleKotlinDsl())
     implementation(libs.kotlinGradlePlugin)
 }
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -8,16 +8,6 @@ plugins {
     `java-gradle-plugin`
 }
 
-// task-034: Gradle 8.13 同梱の `kotlin-dsl` plugin は embedded Kotlin (2.0.21) を要求するが、
-// 本プロジェクトは Kotlin 2.3.21 を使うため毎ビルド `WARNING: Unsupported Kotlin plugin version.`
-// が `:gradle-plugin` の Configure フェーズで出てしまう。
-// Gradle 9 系で embedded Kotlin が更新されれば消える想定だが (task-033 と連動)、それまでの短期 mitigation として
-// `kotlin-dsl` plugin を `org.jetbrains.kotlin.jvm` + `java-gradle-plugin` に分解する。
-// 本ファイルは precompiled `.gradle.kts` を含まないため `kotlin-dsl` 固有機能には依存していない。
-// Gradle Kotlin DSL の拡張 (`getByType<>()` / `register<>()` 等) は `gradleApi()` ではなく
-// `gradleKotlinDsl()` が提供するため、下の dependencies ブロックで `compileOnly(gradleKotlinDsl())`
-// として明示的に追加している。 `gradleKotlinDsl()` を外すと src/ 配下の Kotlin DSL 拡張が解決できなくなる。
-
 kotlin {
     jvmToolchain(libs.versions.jvmToolchain.get().toInt())
     compilerOptions {
@@ -29,8 +19,6 @@ kotlin {
     }
 }
 
-// Kotlin compile task の language/api version を embedded と歩調を合わせる目的ではなく、
-// プロジェクト全体で使う Kotlin 機能の互換 floor を 2.1 に固定する。
 tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
         apiVersion.set(KotlinVersion.KOTLIN_2_1)
@@ -66,9 +54,6 @@ kotlin.sourceSets.named("main") {
 dependencies {
     api(projects.annotation)
     compileOnly(gradleApi())
-    // task-034: `kotlin-dsl` plugin が自動で追加していた Gradle Kotlin DSL API を手動で復元。
-    // build script 本体は precompiled script plugin を含まないが、src/ 配下の Kotlin code は
-    // `getByType<>()`, `register<>()`, ExtensionAware.property delegate などの拡張関数を利用する。
     compileOnly(gradleKotlinDsl())
     implementation(libs.kotlinGradlePlugin)
 }

--- a/gradle-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/ComposePreviewLabSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/ComposePreviewLabSubplugin.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 class ComposePreviewLabSubplugin : KotlinCompilerPluginSupportPlugin {
 
@@ -27,8 +28,10 @@ class ComposePreviewLabSubplugin : KotlinCompilerPluginSupportPlugin {
         val project = kotlinCompilation.target.project
 
         if (project.supportsCompilerPluginOrder()) {
-            kotlinCompilation.compileTaskProvider.configure {
-                compilerOptions.freeCompilerArgs.add(
+            // task-034: `kotlin-dsl` plugin を外したため receiver の型が KotlinCompilationTask<*> へ
+            // 推論されない場合に備え、明示的にパラメータ型を指定する。
+            kotlinCompilation.compileTaskProvider.configure { task: KotlinCompilationTask<*> ->
+                task.compilerOptions.freeCompilerArgs.add(
                     "-Xcompiler-plugin-order=$PreviewLabCompilerPluginId>$ComposeCompilerPluginId",
                 )
             }

--- a/gradle-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/ComposePreviewLabSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/ComposePreviewLabSubplugin.kt
@@ -28,7 +28,7 @@ class ComposePreviewLabSubplugin : KotlinCompilerPluginSupportPlugin {
         val project = kotlinCompilation.target.project
 
         if (project.supportsCompilerPluginOrder()) {
-            // task-034: `kotlin-dsl` plugin を外したため receiver の型が KotlinCompilationTask<*> へ
+            // `kotlin-dsl` plugin を外したため receiver の型が KotlinCompilationTask<*> へ
             // 推論されない場合に備え、明示的にパラメータ型を指定する。
             kotlinCompilation.compileTaskProvider.configure { task: KotlinCompilationTask<*> ->
                 task.compilerOptions.freeCompilerArgs.add(


### PR DESCRIPTION
## Summary

`:gradle-plugin` の Configure フェーズで毎ビルド出ていた以下の warning を除去:

```
> Configure project :gradle-plugin
WARNING: Unsupported Kotlin plugin version.
The `embedded-kotlin` and `kotlin-dsl` plugins rely on features of Kotlin `2.0.21` that might work differently than in the requested version `2.3.21`.
```

Gradle 8.13 同梱の `kotlin-dsl` plugin が embedded Kotlin (2.0.21) を要求するのに対し、本プロジェクトは Kotlin 2.3.21 を使用しているのが原因。

## Fix

`gradle-plugin/build.gradle.kts` から `` `kotlin-dsl` `` plugin を外し、その役割を分解:

- `org.jetbrains.kotlin.jvm` (libs alias) で Kotlin JVM 構成
- `` `java-gradle-plugin` `` で Gradle plugin 配布構成
- `compileOnly(gradleKotlinDsl())` で `kotlin-dsl` plugin が自動で追加していた Gradle Kotlin DSL API (`getByType<>()`, `register<>()`, ExtensionAware.property delegate 等) を補填

本モジュールには precompiled `.gradle.kts` script plugin が存在しないため `kotlin-dsl` 固有機能には依存しておらず、機能等価。`ComposePreviewLabSubplugin.kt` で `compileTaskProvider.configure { ... }` の lambda 引数型推論が落ちる箇所のみ `KotlinCompilationTask<*>` を明示。

## Context

- 検出: Nightly Exploration run `25697742322` (cat3 / P3)
- 関連 ticket: `task-034` (本 PR), `task-033` (Gradle 9 migration audit), `task-030` (wrapper align)
- 短期 mitigation。 恒久対策は task-033 (Gradle 9 系) で embedded Kotlin が更新されれば自動的に解決。

## Test plan

- [x] `./gradlew :gradle-plugin:tasks` で `Unsupported Kotlin plugin version` が出ない
- [x] `./gradlew :dev:tasks` で同上 (報告された symptom が消えた)
- [x] `./gradlew jvmTest --continue` がパスする
- [x] `./gradlew apiCheck --continue` がパスする
- [x] `./gradlew ktlintCheck --continue` がパスする
- [ ] CI (jsBrowserTest, wasmJsBrowserTest, testDebugUnitTest, iosSimulatorArm64Test, integrationTest) の確認

## Out of scope

- Gradle / AGP / Kotlin の version 上げ自体は本 PR の対象外 (task-033 で対応)
- `buildLogic/build.gradle.kts` 側の `kotlin-dsl` は警告が出ていないため未変更 (focus 維持)

🤖 Generated with [Claude Code](https://claude.com/claude-code)