### PR TITLE
refactor(compiler-plugin): centralize CompatContext load via FirSession component

### DIFF
--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ComposePreviewLabCompilerPluginRegistrar.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/ComposePreviewLabCompilerPluginRegistrar.kt
@@ -1,5 +1,6 @@
 package me.tbsten.compose.preview.lab.compiler
 
+import me.tbsten.compose.preview.lab.compiler.compat.CompatContext
 import me.tbsten.compose.preview.lab.compiler.compat.registerExtensionCompat
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
@@ -29,6 +30,7 @@ class ComposePreviewLabCompilerPluginRegistrar : CompilerPluginRegistrar() {
      * different JVM call-site signatures. The reflective wrapper abstracts that away.
      */
     override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
+        val compatContext = CompatContext.load()
         val config = PluginConfig.from(configuration)
         val messageCollector = configuration.get(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY)
             ?: MessageCollector.NONE
@@ -36,11 +38,11 @@ class ComposePreviewLabCompilerPluginRegistrar : CompilerPluginRegistrar() {
         // changed between Kotlin 2.3 and 2.4, so resolve `registerExtension(...)` reflectively.
         registerExtensionCompat(
             FirExtensionRegistrarAdapter.Companion,
-            PreviewLabFirExtensionRegistrar(config),
+            PreviewLabFirExtensionRegistrar(config, compatContext),
         )
         registerExtensionCompat(
             IrGenerationExtension.Companion,
-            PreviewLabIrGenerationExtension(config, messageCollector),
+            PreviewLabIrGenerationExtension(config, messageCollector, compatContext),
         )
     }
 }

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/PreviewLabFirExtensionRegistrar.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/PreviewLabFirExtensionRegistrar.kt
@@ -1,6 +1,7 @@
 package me.tbsten.compose.preview.lab.compiler
 
 import me.tbsten.compose.preview.lab.compiler.compat.CompatContext
+import me.tbsten.compose.preview.lab.compiler.compat.CompatContextSessionComponent
 import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.HintEntriesProvider
 import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.PreviewLabFirBuiltIns
 import me.tbsten.compose.preview.lab.compiler.feature.transformPrivatePreviewToInternal.fir.visibilityPromotion.PreviewLabFirStatusTransformerExtension
@@ -41,10 +42,15 @@ import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
  *   that no `previewHint_<scope>(...)` overload or `PreviewHintMarker_*` interface ends
  *   up in the module's classpath.
  */
-class PreviewLabFirExtensionRegistrar(private val config: PluginConfig) : FirExtensionRegistrar() {
+class PreviewLabFirExtensionRegistrar(private val config: PluginConfig, private val compatContext: CompatContext,) :
+    FirExtensionRegistrar() {
 
     override fun ExtensionRegistrarContext.configurePlugin() {
-        val compat = CompatContext.load()
+        // Register the CompatContext session component first so every later component /
+        // extension can resolve `session.compatContext` instead of receiving the value
+        // through their constructor (= no FIR-side bucket relay). The IR side keeps
+        // explicit constructor injection because it has no FIR session in scope.
+        +({ session: FirSession -> CompatContextSessionComponent(session, compatContext) })
         +({ session: FirSession -> PreviewLabFirBuiltIns(session, config) })
         // Session-scoped lazy cache of `@Preview` → hint/marker metadata. Registered as
         // its own `FirExtensionSessionComponent` so both the (future) hint generator and
@@ -69,11 +75,11 @@ class PreviewLabFirExtensionRegistrar(private val config: PluginConfig) : FirExt
         // emitted inside `ReplaceCollectPreviewsFunBody`) remains active on every Kotlin
         // version as a second-line check, so violations still surface at compile time
         // without the FIR highlighter.
-        if (compat.supportsFirCheckers()) {
+        if (compatContext.supportsFirCheckers()) {
             +::PreviewLabFirCheckersExtension
         }
-        if (compat.supportsFirHintGeneration() && config.collectPreviewsEnabled) {
-            +({ session: FirSession -> PreviewHintFirGenerator(session, compat) })
+        if (compatContext.supportsFirHintGeneration() && config.collectPreviewsEnabled) {
+            +::PreviewHintFirGenerator
         }
     }
 }

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/PreviewLabIrGenerationExtension.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/PreviewLabIrGenerationExtension.kt
@@ -13,9 +13,9 @@ import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.CMP_PREV
 import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.COMPOSE_PREVIEW_LAB_OPTION_FQN
 import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.PreviewFunctionInfo
 import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.ir.collectPreviewsReplacement.BuildPreviewByHashMap
-import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.ir.collectPreviewsReplacement.buildPreviewSequence.extractSourceText
 import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.ir.collectPreviewsReplacement.FillPreviewHintIrBody
 import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.ir.collectPreviewsReplacement.ReplaceCollectPreviewsFunBody
+import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.ir.collectPreviewsReplacement.buildPreviewSequence.extractSourceText
 import me.tbsten.compose.preview.lab.compiler.utils.ir.compilerMessageLocation
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
@@ -42,11 +42,11 @@ import org.jetbrains.kotlin.ir.util.kotlinFqName
 class PreviewLabIrGenerationExtension(
     private val config: PluginConfig,
     private val messageCollector: MessageCollector = MessageCollector.NONE,
+    private val compatContext: CompatContext,
 ) : IrGenerationExtension {
 
     override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
         val previews = collectPreviews(moduleFragment)
-        val compatContext = CompatContext.load()
         val bodyFiller =
             ReplaceCollectPreviewsFunBody(pluginContext, config, moduleFragment, previews, compatContext, messageCollector)
         compatContext.transformModuleFragment(moduleFragment, bodyFiller)

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/compat/Compat.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/compat/Compat.kt
@@ -9,30 +9,31 @@ import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.name.Name
 
 /**
- * Access point for the version-specific Kotlin compiler API.
+ * Returns whether the FIR declaration is a function. See [CompatContext.isFirFunction].
  *
- * The actual differences live in compat modules that implement [CompatContext]
- * (`compiler-plugin/compat-k230`, `compiler-plugin/compat-k240_beta2`, ...).
- * At runtime, ServiceLoader picks the one that matches the current Kotlin compiler.
- *
- * The extension-function shapes here intentionally mirror the ones that used to live
- * in the per-version sourceSets (`kotlin-2.3/`, ...) so call sites do not need to change.
+ * Resolves the version-specific [CompatContext] via [FirSession.compatContext], so callers
+ * only need the FIR session in scope.
  */
-private val compatContext: CompatContext by lazy { CompatContext.load() }
-
-/** Returns whether the FIR declaration is a function. See [CompatContext.isFirFunction]. */
-internal fun FirDeclaration.isFirFunction(): Boolean = compatContext.isFirFunction(this)
+internal fun FirDeclaration.isFirFunction(session: FirSession): Boolean = session.compatContext.isFirFunction(this)
 
 /**
  * Builds an annotation from the given constructor symbol and adds it to the function.
  * See [CompatContext.addConstructorCallAnnotation].
+ *
+ * IR-side: no FIR session in scope, so the [compatContext] is passed explicitly (= bucket
+ * relay continues on the IR side, by design — see the registrar for the entry-point load).
  */
-internal fun IrSimpleFunction.addConstructorCallAnnotation(type: IrType, constructorSymbol: IrConstructorSymbol) =
-    compatContext.addConstructorCallAnnotation(this, type, constructorSymbol)
+internal fun IrSimpleFunction.addConstructorCallAnnotation(
+    compatContext: CompatContext,
+    type: IrType,
+    constructorSymbol: IrConstructorSymbol,
+) = compatContext.addConstructorCallAnnotation(this, type, constructorSymbol)
 
 /**
  * Returns the resolved `Boolean` argument named [name] from this annotation, or `null` when
  * the argument is absent or unresolvable. See [CompatContext.getBooleanArgumentCompat].
+ *
+ * Resolves [CompatContext] via [FirSession.compatContext] from the supplied [session].
  */
 internal fun FirAnnotation.getBooleanArgumentCompat(name: Name, session: FirSession): Boolean? =
-    compatContext.getBooleanArgumentCompat(this, name, session)
+    session.compatContext.getBooleanArgumentCompat(this, name, session)

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/compat/CompatContextSessionComponent.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/compat/CompatContextSessionComponent.kt
@@ -1,0 +1,27 @@
+package me.tbsten.compose.preview.lab.compiler.compat
+
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.extensions.FirExtensionSessionComponent
+
+/**
+ * Session-bound accessor for the version-specific [CompatContext] instance loaded once
+ * at plugin entry (`ComposePreviewLabCompilerPluginRegistrar`).
+ *
+ * Registered as the *first* component in [me.tbsten.compose.preview.lab.compiler.PreviewLabFirExtensionRegistrar]
+ * so every later FIR component / extension can resolve `session.compatContext`
+ * without having to thread the value through each constructor. Pattern adapted from
+ * [me.tbsten.compose.preview.lab.compiler.feature.previewCollection.HintEntriesProvider].
+ *
+ * **Sample access** (inside any FIR extension that has `session` in scope):
+ * ```kotlin
+ * session.compatContext.getDeprecationsProviderCompat(declaration, session)
+ * ```
+ */
+internal class CompatContextSessionComponent(session: FirSession, val value: CompatContext,) :
+    FirExtensionSessionComponent(session)
+
+internal val FirSession.compatContext: CompatContext
+    get() = compatContextSessionComponent.value
+
+private val FirSession.compatContextSessionComponent: CompatContextSessionComponent
+    by FirSession.sessionComponentAccessor()

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/HintEntriesProvider.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/HintEntriesProvider.kt
@@ -1,9 +1,8 @@
 package me.tbsten.compose.preview.lab.compiler.feature.previewCollection
 
-import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.fir.scopeValidation.SCOPE_VALIDATION_REGEX
-
 import me.tbsten.compose.preview.lab.ComposePreviewLabOption
 import me.tbsten.compose.preview.lab.compiler.compat.getBooleanArgumentCompat
+import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.fir.scopeValidation.SCOPE_VALIDATION_REGEX
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
 import org.jetbrains.kotlin.fir.declarations.toAnnotationClassIdSafe

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/AttachInternalApi.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/AttachInternalApi.kt
@@ -1,6 +1,6 @@
 package me.tbsten.compose.preview.lab.compiler.feature.previewCollection.fir
 
-import me.tbsten.compose.preview.lab.compiler.compat.CompatContext
+import me.tbsten.compose.preview.lab.compiler.compat.compatContext
 import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.INTERNAL_COMPOSE_PREVIEW_LAB_API_CLASS_ID
 import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.SYNTHETIC_PREVIEW_HINT_CLASS_ID
 import me.tbsten.compose.preview.lab.compiler.utils.fir.buildSimpleAnnotation
@@ -35,14 +35,14 @@ import org.jetbrains.kotlin.fir.declarations.FirClassLikeDeclaration
  *   `me.tbsten.compose.preview.lab.hints` package, so a downstream
  *   `collectAllModulePreviews()` cannot be poisoned by namespace squatting.
  */
-internal fun FirClassLikeDeclaration.markAsInternalSyntheticHint(session: FirSession, compat: CompatContext) {
+internal fun FirClassLikeDeclaration.markAsInternalSyntheticHint(session: FirSession) {
     replaceAnnotations(
         annotations + listOf(
             INTERNAL_COMPOSE_PREVIEW_LAB_API_CLASS_ID.buildSimpleAnnotation(session),
             SYNTHETIC_PREVIEW_HINT_CLASS_ID.buildSimpleAnnotation(session),
         ),
     )
-    compat.getDeprecationsProviderCompat(this, session)?.let(::replaceDeprecationsProvider)
+    session.compatContext.getDeprecationsProviderCompat(this, session)?.let(::replaceDeprecationsProvider)
 }
 
 /**
@@ -53,12 +53,12 @@ internal fun FirClassLikeDeclaration.markAsInternalSyntheticHint(session: FirSes
  * Targets: the per-`@Preview` `previewHint_<scope>(...)` overloads emitted by
  * `PreviewHintFirGenerator`.
  */
-internal fun FirCallableDeclaration.markAsInternalSyntheticHint(session: FirSession, compat: CompatContext) {
+internal fun FirCallableDeclaration.markAsInternalSyntheticHint(session: FirSession) {
     replaceAnnotations(
         annotations + listOf(
             INTERNAL_COMPOSE_PREVIEW_LAB_API_CLASS_ID.buildSimpleAnnotation(session),
             SYNTHETIC_PREVIEW_HINT_CLASS_ID.buildSimpleAnnotation(session),
         ),
     )
-    compat.getDeprecationsProviderCompat(this, session)?.let(::replaceDeprecationsProvider)
+    session.compatContext.getDeprecationsProviderCompat(this, session)?.let(::replaceDeprecationsProvider)
 }

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintAndMarkerGeneration/PreviewHintFirGenerator.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintAndMarkerGeneration/PreviewHintFirGenerator.kt
@@ -4,7 +4,6 @@
 
 package me.tbsten.compose.preview.lab.compiler.feature.previewCollection.fir.hintAndMarkerGeneration
 
-import me.tbsten.compose.preview.lab.compiler.compat.CompatContext
 import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.HintEntry
 import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.PreviewAnnotationPredicates
 import me.tbsten.compose.preview.lab.compiler.feature.previewCollection.PreviewKeys
@@ -120,8 +119,7 @@ import org.jetbrains.kotlin.name.Name
  * [ContributionHintFirGenerator](https://github.com/ZacSweers/metro/blob/main/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributionHintFirGenerator.kt),
  * combined with the fixed-name discovery approach of the legacy module-aggregation hint.
  */
-internal class PreviewHintFirGenerator(session: FirSession, private val compat: CompatContext,) :
-    FirDeclarationGenerationExtension(session) {
+internal class PreviewHintFirGenerator(session: FirSession) : FirDeclarationGenerationExtension(session) {
 
     /**
      * Session-shared per-`@Preview` metadata, populated lazily by
@@ -222,14 +220,14 @@ internal class PreviewHintFirGenerator(session: FirSession, private val compat: 
         val klass = createTopLevelClass(classId, PreviewKeys.PreviewLabHintMarkerInterface, ClassKind.INTERFACE) {
             modality = Modality.ABSTRACT
         }
-        klass.markAsDeprecatedHidden(session, compat)
-        klass.markAsInternalSyntheticHint(session, compat)
+        klass.markAsDeprecatedHidden(session)
+        klass.markAsInternalSyntheticHint(session)
         return klass.symbol
     }
 
     override fun generateConstructors(context: MemberGenerationContext): List<FirConstructorSymbol> = emptyList()
 
-    override fun getCallableNamesForClass(classSymbol: FirClassSymbol<*>, context: MemberGenerationContext,): Set<Name> =
+    override fun getCallableNamesForClass(classSymbol: FirClassSymbol<*>, context: MemberGenerationContext): Set<Name> =
         emptySet()
 
     /**
@@ -298,8 +296,8 @@ internal class PreviewHintFirGenerator(session: FirSession, private val compat: 
                     type = markerSymbol.constructType(isMarkedNullable = true),
                 )
             }.also {
-                it.markAsDeprecatedHidden(session, compat)
-                it.markAsInternalSyntheticHint(session, compat)
+                it.markAsDeprecatedHidden(session)
+                it.markAsInternalSyntheticHint(session)
             }.symbol
         }
     }

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintGeneration/DeprecationHidden.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/fir/hintGeneration/DeprecationHidden.kt
@@ -1,6 +1,6 @@
 package me.tbsten.compose.preview.lab.compiler.feature.previewCollection.fir.hintGeneration
 
-import me.tbsten.compose.preview.lab.compiler.compat.CompatContext
+import me.tbsten.compose.preview.lab.compiler.compat.compatContext
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirCallableDeclaration
 import org.jetbrains.kotlin.fir.declarations.FirClassLikeDeclaration
@@ -100,9 +100,9 @@ internal fun createDeprecatedHiddenAnnotation(session: FirSession): FirAnnotatio
  * resolution. [CompatContext.getDeprecationsProviderCompat] absorbs the 2.4.0-Beta2
  * receiver narrowing.
  */
-internal fun FirClassLikeDeclaration.markAsDeprecatedHidden(session: FirSession, compat: CompatContext) {
+internal fun FirClassLikeDeclaration.markAsDeprecatedHidden(session: FirSession) {
     replaceAnnotations(annotations + listOf(createDeprecatedHiddenAnnotation(session)))
-    compat.getDeprecationsProviderCompat(this, session)?.let(::replaceDeprecationsProvider)
+    session.compatContext.getDeprecationsProviderCompat(this, session)?.let(::replaceDeprecationsProvider)
 }
 
 /**
@@ -125,7 +125,7 @@ internal fun FirClassLikeDeclaration.markAsDeprecatedHidden(session: FirSession,
  * public fun previewHint(value: PreviewHintMarker_<...>?): CollectedPreview
  * ```
  */
-internal fun FirCallableDeclaration.markAsDeprecatedHidden(session: FirSession, compat: CompatContext) {
+internal fun FirCallableDeclaration.markAsDeprecatedHidden(session: FirSession) {
     replaceAnnotations(annotations + listOf(createDeprecatedHiddenAnnotation(session)))
-    compat.getDeprecationsProviderCompat(this, session)?.let(::replaceDeprecationsProvider)
+    session.compatContext.getDeprecationsProviderCompat(this, session)?.let(::replaceDeprecationsProvider)
 }

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/buildPreviewSequence/BuildCollectedPreviewIr.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/previewCollection/ir/collectPreviewsReplacement/buildPreviewSequence/BuildCollectedPreviewIr.kt
@@ -173,6 +173,7 @@ internal class BuildCollectedPreviewIr(private val pluginContext: IrPluginContex
         val composableClass = pluginContext.referenceClass(composableClassId) ?: return
         val ctor = composableClass.constructors.firstOrNull() ?: return
         func.addConstructorCallAnnotation(
+            compatContext = compatContext,
             type = compatContext.getDefaultType(composableClass),
             constructorSymbol = ctor,
         )

--- a/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/transformPrivatePreviewToInternal/fir/visibilityPromotion/PreviewLabFirStatusTransformerExtension.kt
+++ b/compiler-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/compiler/feature/transformPrivatePreviewToInternal/fir/visibilityPromotion/PreviewLabFirStatusTransformerExtension.kt
@@ -43,7 +43,7 @@ class PreviewLabFirStatusTransformerExtension(session: FirSession) : FirStatusTr
      * a Compose `@Preview` annotation.
      */
     override fun needTransformStatus(declaration: FirDeclaration): Boolean {
-        if (!declaration.isFirFunction()) return false
+        if (!declaration.isFirFunction(session)) return false
         if (declaration !is FirMemberDeclaration) return false
         if (declaration.visibility != Visibilities.Private) return false
         return previewAnnotations.any { classId -> declaration.hasPreviewAnnotation(classId) }


### PR DESCRIPTION
## Summary

- `CompatContext.load()` がプラグイン内で 3 箇所から呼ばれていたのを、 entry point (`ComposePreviewLabCompilerPluginRegistrar`) 1 箇所に集約。
- FIR 側は `CompatContextSessionComponent` + `FirSession.sessionComponentAccessor()` で `session.compatContext` としてアクセス可能に。 既存の `FirSession.hintEntriesProvider` パターンを踏襲。
- FIR 側のバケツリレー (`HintEntriesProvider` / `PreviewLabFirStatusTransformerExtension` / `PreviewHintFirGenerator` / `markAs*` ヘルパー) を解消。
- IR 側は FIR session が無いので constructor injection は据え置き (`PreviewLabIrGenerationExtension(... , compatContext)` / `addConstructorCallAnnotation(compatContext, ...)`)。

### Why

`CompatContext.load()` は ServiceLoader 経由で同じバージョン用 impl を毎回作る stateless 操作で機能差はないが、 SSoT 違反 + ServiceLoader 走査が 3 重で発生していた。
ConeTypeRegistry のように session-bound にして「session に聞けば取れる」 状態にする。

## Test plan

- [x] `./gradlew :compiler-plugin:compileKotlin` 成功
- [x] `./gradlew :compiler-plugin:ktlintCheck` 成功
- [x] `./gradlew :compiler-plugin:test -Dkotest.tags='!PBT'` 成功
- [x] `./gradlew apiCheck` 成功 (全 module の binary compat)
- [ ] CI で他 platform (jsBrowserTest / wasmJsBrowserTest / testDebugUnitTest / iosSimulatorArm64Test) と PBT を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)