### PR TITLE
refactor(gradle-plugin): apply convention-jvm instead of manual toolchain/optIn (task-049)

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -4,21 +4,14 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     alias(libs.plugins.conventionFormat)
     alias(libs.plugins.conventionPublish)
-    alias(libs.plugins.kotlinJvm)
+    alias(libs.plugins.conventionJvm)
     `java-gradle-plugin`
 }
 
-kotlin {
-    jvmToolchain(libs.versions.jvmToolchain.get().toInt())
-    compilerOptions {
-        optIn.addAll(
-            "me.tbsten.compose.preview.lab.ExperimentalComposePreviewLabApi",
-            "me.tbsten.compose.preview.lab.InternalComposePreviewLabApi",
-            "me.tbsten.compose.preview.lab.UiComposePreviewLabApi",
-        )
-    }
-}
-
+// プロジェクト全体で使う Kotlin 機能の互換 floor を 2.1 に固定する。
+// gradle-plugin はユーザの Gradle (embedded Kotlin が古い可能性あり) 上で動作するため、
+// 新しめの Kotlin 言語機能を取り込まないよう apiVersion/languageVersion を明示的に固定する。
+// convention-jvm は language/api version を設定しないので、ここで個別に設定する。
 tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
         apiVersion.set(KotlinVersion.KOTLIN_2_1)


### PR DESCRIPTION
## Summary

- `:gradle-plugin/build.gradle.kts` が `convention-jvm` の提供する toolchain / opt-in 設定を手動再実装していた SoT 違反を解消する。
- `alias(libs.plugins.kotlinJvm)` を `alias(libs.plugins.conventionJvm)` に置き換え、`jvmToolchain` と `COMMON_OPT_INS` を `JvmConventionPlugin` 経由で適用する。

## 動機

PR #223 (task-034) で `kotlin-dsl` plugin を外す際、 当時の判断として「`kotlin-dsl` が提供する embedded Kotlin と当プロジェクトの Kotlin 2.3.21 が噛み合わない警告」を避けるために `alias(libs.plugins.kotlinJvm)` + 手動 `jvmToolchain` + 手動 `optIn.addAll(...)` という構成にした。

しかしこの構成は `convention-jvm` (= `buildLogic/src/main/kotlin/JvmConventionPlugin.kt`) と同じ内容を `:gradle-plugin` 内で重複定義しており、 `COMMON_OPT_INS` (`buildLogic/src/main/kotlin/util/Android.kt`) に opt-in アノテーションが追加された際の追従漏れリスクがある。 ticket task-049 の指摘どおり SoT 違反なので解消する。

## 変更詳細

```diff
 plugins {
     alias(libs.plugins.conventionFormat)
     alias(libs.plugins.conventionPublish)
-    alias(libs.plugins.kotlinJvm)
+    alias(libs.plugins.conventionJvm)
     `java-gradle-plugin`
 }

-kotlin {
-    jvmToolchain(libs.versions.jvmToolchain.get().toInt())
-    compilerOptions {
-        optIn.addAll(
-            "me.tbsten.compose.preview.lab.ExperimentalComposePreviewLabApi",
-            "me.tbsten.compose.preview.lab.InternalComposePreviewLabApi",
-            "me.tbsten.compose.preview.lab.UiComposePreviewLabApi",
-        )
-    }
-}
-
+// 全体の Kotlin 機能互換 floor を 2.1 に固定 (gradle-plugin 固有制約)
 tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
         apiVersion.set(KotlinVersion.KOTLIN_2_1)
         languageVersion.set(KotlinVersion.KOTLIN_2_1)
     }
 }
```

`compileOnly(gradleApi())` / `compileOnly(gradleKotlinDsl())` は task-034 で `kotlin-dsl` plugin が抜けた分の代替なので そのまま残す。

## KOTLIN_2_1 固定設定の扱い

`tasks.withType<KotlinCompile>().configureEach { apiVersion/languageVersion = KOTLIN_2_1 }` は **残した**。

理由:
- `:gradle-plugin` はユーザ側 Gradle (= 古めの embedded Kotlin が同梱されている可能性が高い) 上で動作するので、 過剰に新しい Kotlin 言語機能を取り込まないよう floor を 2.1 に固定する意味がある (PR #223 のレビュー意図そのまま)。
- `convention-jvm` 側に持ち込むと `:compiler-plugin` など他モジュールにも 2.1 floor が掛かってしまうので、 個別設定として `:gradle-plugin` に残すのが妥当と判断した。
- 不要にできるかは別 ticket (task-033 の Gradle 9 系移行で embedded Kotlin が更新された後など) で再検証する。

## 検証結果

すべて成功。 ログは `.local/tmp/<timestamp>-*.log` に保存。

| コマンド | 結果 |
|---|---|
| `./gradlew :dev:tasks` | SUCCESS / `Unsupported Kotlin plugin version` 警告なし (`grep -i "Unsupported Kotlin plugin" => 0 hit`) |
| `./gradlew :gradle-plugin:assemble --continue` | SUCCESS |
| `./gradlew :gradle-plugin:clean :gradle-plugin:compileKotlin --rerun-tasks` | SUCCESS (cache を回避した完全コンパイル確認) |
| `./gradlew ktlintCheck --continue` | SUCCESS |
| `./gradlew apiCheck --continue` | SUCCESS |
| `./gradlew jvmTest --continue` | SUCCESS |
| `./gradlew publishToMavenLocal` | SUCCESS |
| `(cd integrationTest && ./gradlew jvmTest --continue)` | SUCCESS |

## Test plan

- [x] `:dev:tasks` で `Unsupported Kotlin plugin version` 警告が出ない (PR #223 と同条件維持)
- [x] `:gradle-plugin:assemble` 成功
- [x] `jvmTest` / `apiCheck` / `ktlintCheck` 成功
- [x] `publishToMavenLocal` 成功
- [x] integrationTest の `jvmTest` 成功
- [ ] CI 上で iOS / JS / Wasm / Android 各テストも green になることを GitHub Actions で確認

## Optional follow-up (本 PR の範囲外)

- `buildLogic/build.gradle.kts` 側の `kotlin-dsl` plugin が embedded Kotlin 警告を出している可能性 (task-034 と同じく Gradle 9 系移行 = task-033 で解消想定)。 別 ticket で別途検討する。

## 関連

- 親 PR / 前提: PR #223 (task-034) merge commit `4f179b6e` 後の follow-up
- ticket: `.local/ticket/task-049-gradle-plugin-conventionjvm-dry-violation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)