### PR TITLE
feat(dokka-plugin): embed PreviewLab in KDoc via @previewLab tag (試作, issue #96)

### DIFF
--- a/buildLogic/src/main/kotlin/Dokka.kt
+++ b/buildLogic/src/main/kotlin/Dokka.kt
@@ -5,8 +5,14 @@ import util.dokka
 import util.libs
 import util.plugin
 
+private const val DOKKA_PLUGIN_PROJECT_PATH = ":dokka-plugin"
+
 fun Project.configureDokka(publishConventionExtension: PublishConventionExtension) {
     pluginManager.apply(libs.plugin("dokka").pluginId)
+
+    if (path != DOKKA_PLUGIN_PROJECT_PATH) {
+        dependencies.add("dokkaPlugin", dependencies.project(mapOf("path" to DOKKA_PLUGIN_PROJECT_PATH)))
+    }
 
     afterEvaluate {
         extensions.configure<DokkaExtension> {

--- a/dokka-plugin/api/dokka-plugin.api
+++ b/dokka-plugin/api/dokka-plugin.api
@@ -1,0 +1,12 @@
+public final class me/tbsten/compose/preview/lab/dokka/ComposePreviewLabDokkaPlugin : org/jetbrains/dokka/plugability/DokkaPlugin {
+	public fun <init> ()V
+	public final fun getPreviewLabRenderer ()Lorg/jetbrains/dokka/plugability/Extension;
+	public final fun getPreviewLabTagContentProvider ()Lorg/jetbrains/dokka/plugability/Extension;
+}
+
+public class me/tbsten/compose/preview/lab/dokka/PreviewLabHtmlRenderer : org/jetbrains/dokka/base/renderers/html/HtmlRenderer {
+	public fun <init> (Lorg/jetbrains/dokka/plugability/DokkaContext;)V
+	public synthetic fun buildCodeBlock (Ljava/lang/Object;Lorg/jetbrains/dokka/pages/ContentCodeBlock;Lorg/jetbrains/dokka/pages/ContentPage;)V
+	public fun buildCodeBlock (Lkotlinx/html/FlowContent;Lorg/jetbrains/dokka/pages/ContentCodeBlock;Lorg/jetbrains/dokka/pages/ContentPage;)V
+}
+

--- a/dokka-plugin/build.gradle.kts
+++ b/dokka-plugin/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    alias(libs.plugins.conventionFormat)
+    alias(libs.plugins.conventionPublish)
+    alias(libs.plugins.conventionJvm)
+}
+
+dependencies {
+    compileOnly(libs.dokkaCore)
+    implementation(libs.dokkaBase)
+    implementation(libs.kotlinxHtml)
+
+    testImplementation(libs.dokkaCore)
+    testImplementation(libs.dokkaBase)
+    testImplementation(libs.dokkaTestApi)
+    testImplementation(libs.dokkaBaseTestUtils)
+    testImplementation(libs.dokkaAnalysisKotlinSymbols)
+    testImplementation(libs.jsoup)
+    testImplementation(libs.junitJupiter)
+    testImplementation(libs.kotestAssertionsCore)
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+}
+
+publishConvention {
+    artifactName = "Dokka Plugin"
+    artifactId = "dokka-plugin"
+    description =
+        "Dokka plugin for Compose Preview Lab. " +
+        "Embeds PreviewLab previews into generated KDoc via the @previewLab tag."
+}

--- a/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/ComposePreviewLabDokkaPlugin.kt
+++ b/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/ComposePreviewLabDokkaPlugin.kt
@@ -1,0 +1,24 @@
+package me.tbsten.compose.preview.lab.dokka
+
+import org.jetbrains.dokka.CoreExtensions
+import org.jetbrains.dokka.base.DokkaBase
+import org.jetbrains.dokka.plugability.DokkaPlugin
+import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
+import org.jetbrains.dokka.plugability.PluginApiPreviewAcknowledgement
+
+public class ComposePreviewLabDokkaPlugin : DokkaPlugin() {
+    private val dokkaBase by lazy { plugin<DokkaBase>() }
+
+    public val previewLabRenderer by extending {
+        CoreExtensions.renderer providing { PreviewLabHtmlRenderer(it) } override dokkaBase.htmlRenderer
+    }
+
+    public val previewLabTagContentProvider by extending {
+        dokkaBase.customTagContentProvider with PreviewLabTagContentProvider order {
+            before(dokkaBase.sinceKotlinTagContentProvider)
+        }
+    }
+
+    @OptIn(DokkaPluginApiPreview::class)
+    override fun pluginApiPreviewAcknowledgement(): PluginApiPreviewAcknowledgement = PluginApiPreviewAcknowledgement
+}

--- a/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/PreviewLabHtmlRenderer.kt
+++ b/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/PreviewLabHtmlRenderer.kt
@@ -19,6 +19,15 @@ import org.jetbrains.dokka.plugability.DokkaContext
 internal const val PreviewLabBaseUrlProperty: String = "previewLab.dokka.baseUrl"
 internal const val PreviewLabDefaultBaseUrl: String = "compose-preview-lab-gallery"
 
+// Known limitation: Dokka v2 runs the generator in a forked worker
+// (ProcessIsolation), so `-DpreviewLab.dokka.baseUrl=...` set on the Gradle
+// invocation or via `systemProp.` in `gradle.properties` does NOT reach this
+// renderer. A reliable override path is the next milestone — exposing a
+// typed `DokkaPluginParametersBaseSpec` (ConfigurableBlock) consumers set
+// in the `dokka { pluginsConfiguration { ... } }` DSL. Until then the
+// property is honoured only in in-process callers (e.g. the unit tests),
+// and real-build callers get the default base URL.
+
 public open class PreviewLabHtmlRenderer(context: DokkaContext) : HtmlRenderer(context) {
     override fun FlowContent.buildCodeBlock(code: ContentCodeBlock, pageContext: ContentPage) {
         if (code.language == PreviewLabIframeCode) {

--- a/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/PreviewLabHtmlRenderer.kt
+++ b/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/PreviewLabHtmlRenderer.kt
@@ -42,9 +42,13 @@ public open class PreviewLabHtmlRenderer(context: DokkaContext) : HtmlRenderer(c
         val baseUrl = System.getProperty(PreviewLabBaseUrlProperty, PreviewLabDefaultBaseUrl)
         val src = "$baseUrl/?iframe&previewId=$previewId"
 
+        // The default size targets the full PreviewLab UI (header + sidebar + preview area
+        // + inspectors panel). A too-small height squeezes the canvas Compose wasm allocates,
+        // making content look blurry on high-DPI screens. Consumers can override via CSS on
+        // the `iframe.preview-lab-embedded` / `.preview-lab-embedded-container` selectors.
         div(classes = "preview-lab-embedded-container") {
             iframe(classes = "preview-lab-embedded") {
-                style = "display: block; width: 100%; height: 480px; border: 0; margin: 16px auto;"
+                style = "display: block; width: 100%; height: 720px; border: 0; margin: 16px auto;"
                 this.src = src
                 attributes["loading"] = "lazy"
                 attributes["allow"] = "clipboard-read; clipboard-write"

--- a/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/PreviewLabHtmlRenderer.kt
+++ b/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/PreviewLabHtmlRenderer.kt
@@ -19,6 +19,27 @@ import org.jetbrains.dokka.plugability.DokkaContext
 internal const val PreviewLabBaseUrlProperty: String = "previewLab.dokka.baseUrl"
 internal const val PreviewLabDefaultBaseUrl: String = "compose-preview-lab-gallery"
 
+// `<width>x<height>` (integers, lowercase `x`). Used as the iframe's CSS
+// `aspect-ratio` so the embedded preview keeps its shape across screen widths.
+internal val PreviewLabSizeRegex: Regex = Regex("""^(\d+)x(\d+)$""")
+
+internal data class PreviewLabTagPayload(val previewId: String, val aspectRatio: Pair<Int, Int>?) {
+    companion object {
+        fun parse(raw: String): PreviewLabTagPayload? {
+            val tokens = raw.trim().split(Regex("""\s+"""))
+            val previewId = tokens.firstOrNull()?.takeIf { it.isNotEmpty() } ?: return null
+            val aspectRatio = tokens.drop(1)
+                .firstNotNullOfOrNull { token ->
+                    PreviewLabSizeRegex.matchEntire(token)?.let {
+                        val (w, h) = it.destructured
+                        w.toInt() to h.toInt()
+                    }
+                }
+            return PreviewLabTagPayload(previewId, aspectRatio)
+        }
+    }
+}
+
 // Known limitation: Dokka v2 runs the generator in a forked worker
 // (ProcessIsolation), so `-DpreviewLab.dokka.baseUrl=...` set on the Gradle
 // invocation or via `systemProp.` in `gradle.properties` does NOT reach this
@@ -38,17 +59,23 @@ public open class PreviewLabHtmlRenderer(context: DokkaContext) : HtmlRenderer(c
     }
 
     private fun FlowContent.renderPreviewLabIframe(code: ContentCodeBlock) {
-        val previewId = (code.children.singleOrNull() as? ContentText)?.text.orEmpty()
+        val rawPayload = (code.children.singleOrNull() as? ContentText)?.text.orEmpty()
+        val payload = PreviewLabTagPayload.parse(rawPayload) ?: return
         val baseUrl = System.getProperty(PreviewLabBaseUrlProperty, PreviewLabDefaultBaseUrl)
-        val src = "$baseUrl/?iframe&previewId=$previewId"
+        val src = "$baseUrl/?iframe&previewId=${payload.previewId}"
 
-        // The default size targets the full PreviewLab UI (header + sidebar + preview area
-        // + inspectors panel). A too-small height squeezes the canvas Compose wasm allocates,
-        // making content look blurry on high-DPI screens. Consumers can override via CSS on
-        // the `iframe.preview-lab-embedded` / `.preview-lab-embedded-container` selectors.
+        // Default sizing keeps a fixed 720px height (enough for the full PreviewLab UI on a
+        // typical doc-site column width without making the canvas Compose wasm allocates
+        // look blurry on high-DPI screens). When the tag explicitly specifies `WxH`, switch
+        // to aspect-ratio so the iframe scales with the column while preserving the ratio.
+        val sizeStyle = when (val ar = payload.aspectRatio) {
+            null -> "width: 100%; height: 720px;"
+            else -> "width: 100%; aspect-ratio: ${ar.first} / ${ar.second}; height: auto;"
+        }
+
         div(classes = "preview-lab-embedded-container") {
             iframe(classes = "preview-lab-embedded") {
-                style = "display: block; width: 100%; height: 720px; border: 0; margin: 16px auto;"
+                style = "display: block; $sizeStyle border: 0; margin: 16px auto;"
                 this.src = src
                 attributes["loading"] = "lazy"
                 attributes["allow"] = "clipboard-read; clipboard-write"

--- a/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/PreviewLabHtmlRenderer.kt
+++ b/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/PreviewLabHtmlRenderer.kt
@@ -1,0 +1,70 @@
+package me.tbsten.compose.preview.lab.dokka
+
+import java.util.Locale
+import kotlinx.html.FlowContent
+import kotlinx.html.code
+import kotlinx.html.div
+import kotlinx.html.iframe
+import kotlinx.html.pre
+import kotlinx.html.span
+import kotlinx.html.style
+import org.jetbrains.dokka.base.renderers.html.HtmlRenderer
+import org.jetbrains.dokka.pages.ContentCodeBlock
+import org.jetbrains.dokka.pages.ContentPage
+import org.jetbrains.dokka.pages.ContentStyle
+import org.jetbrains.dokka.pages.ContentText
+import org.jetbrains.dokka.pages.TextStyle
+import org.jetbrains.dokka.plugability.DokkaContext
+
+internal const val PreviewLabBaseUrlProperty: String = "previewLab.dokka.baseUrl"
+internal const val PreviewLabDefaultBaseUrl: String = "compose-preview-lab-gallery"
+
+public open class PreviewLabHtmlRenderer(context: DokkaContext) : HtmlRenderer(context) {
+    override fun FlowContent.buildCodeBlock(code: ContentCodeBlock, pageContext: ContentPage) {
+        if (code.language == PreviewLabIframeCode) {
+            renderPreviewLabIframe(code)
+        } else {
+            renderDefaultSampleContainer(code, pageContext)
+        }
+    }
+
+    private fun FlowContent.renderPreviewLabIframe(code: ContentCodeBlock) {
+        val previewId = (code.children.singleOrNull() as? ContentText)?.text.orEmpty()
+        val baseUrl = System.getProperty(PreviewLabBaseUrlProperty, PreviewLabDefaultBaseUrl)
+        val src = "$baseUrl/?iframe&previewId=$previewId"
+
+        div(classes = "preview-lab-embedded-container") {
+            iframe(classes = "preview-lab-embedded") {
+                style = "display: block; width: 100%; height: 480px; border: 0; margin: 16px auto;"
+                this.src = src
+                attributes["loading"] = "lazy"
+                attributes["allow"] = "clipboard-read; clipboard-write"
+            }
+        }
+    }
+
+    // Mirrors the default HtmlRenderer fallback for non-iframe code blocks; we cannot call
+    // `super.buildCodeBlock(...)` because Kotlin does not allow super-calls on overridden
+    // extension functions.
+    private fun FlowContent.renderDefaultSampleContainer(code: ContentCodeBlock, pageContext: ContentPage) {
+        div("sample-container") {
+            val codeLang = "lang-" + code.language.ifEmpty { "kotlin" }
+            val stylesWithBlock = code.style + TextStyle.Block + codeLang
+            pre {
+                code(stylesWithBlock.joinToString(" ") { it.toString().lowercase(Locale.ROOT) }) {
+                    attributes["theme"] = "idea"
+                    code.children.forEach { buildContentNode(it, pageContext) }
+                }
+            }
+            if (!code.style.contains(ContentStyle.RunnableSample)) {
+                span(classes = "top-right-position") {
+                    span("copy-icon")
+                    div("copy-popup-wrapper popup-to-left") {
+                        span("copy-popup-icon")
+                        span { text("Content copied to clipboard") }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/PreviewLabHtmlRenderer.kt
+++ b/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/PreviewLabHtmlRenderer.kt
@@ -68,14 +68,16 @@ public open class PreviewLabHtmlRenderer(context: DokkaContext) : HtmlRenderer(c
         // typical doc-site column width without making the canvas Compose wasm allocates
         // look blurry on high-DPI screens). When the tag explicitly specifies `WxH`, switch
         // to aspect-ratio so the iframe scales with the column while preserving the ratio.
+        // `calc(100% - 32px)` leaves 16px on each side once `margin: 16px` is applied,
+        // so the iframe is fully inset within its container without horizontal overflow.
         val sizeStyle = when (val ar = payload.aspectRatio) {
-            null -> "width: 100%; height: 720px;"
-            else -> "width: 100%; aspect-ratio: ${ar.first} / ${ar.second}; height: auto;"
+            null -> "width: calc(100% - 32px); height: 720px;"
+            else -> "width: calc(100% - 32px); aspect-ratio: ${ar.first} / ${ar.second}; height: auto;"
         }
 
         div(classes = "preview-lab-embedded-container") {
             iframe(classes = "preview-lab-embedded") {
-                style = "display: block; $sizeStyle border: 0; margin: 16px auto;"
+                style = "display: block; $sizeStyle border: 2px solid #d0d7de; margin: 16px;"
                 this.src = src
                 attributes["loading"] = "lazy"
                 attributes["allow"] = "clipboard-read; clipboard-write"

--- a/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/PreviewLabHtmlRenderer.kt
+++ b/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/PreviewLabHtmlRenderer.kt
@@ -1,5 +1,6 @@
 package me.tbsten.compose.preview.lab.dokka
 
+import java.net.URLEncoder
 import java.util.Locale
 import kotlinx.html.FlowContent
 import kotlinx.html.code
@@ -29,13 +30,20 @@ internal data class PreviewLabTagPayload(val previewId: String, val aspectRatio:
             val tokens = raw.trim().split(Regex("""\s+"""))
             val previewId = tokens.firstOrNull()?.takeIf { it.isNotEmpty() } ?: return null
             val aspectRatio = tokens.drop(1)
-                .firstNotNullOfOrNull { token ->
-                    PreviewLabSizeRegex.matchEntire(token)?.let {
-                        val (w, h) = it.destructured
-                        w.toInt() to h.toInt()
-                    }
-                }
+                .firstNotNullOfOrNull { token -> parseAspectRatio(token) }
             return PreviewLabTagPayload(previewId, aspectRatio)
+        }
+
+        // Returns null for anything that isn't a strictly positive `<w>x<h>` token.
+        // Uses `toIntOrNull` so values that exceed `Int.MAX_VALUE` (e.g. 999999999999x1)
+        // safely fall back to the default sizing instead of throwing `NumberFormatException`
+        // and breaking Dokka generation.
+        private fun parseAspectRatio(token: String): Pair<Int, Int>? {
+            val match = PreviewLabSizeRegex.matchEntire(token) ?: return null
+            val (wRaw, hRaw) = match.destructured
+            val w = wRaw.toIntOrNull()?.takeIf { it > 0 } ?: return null
+            val h = hRaw.toIntOrNull()?.takeIf { it > 0 } ?: return null
+            return w to h
         }
     }
 }
@@ -61,8 +69,9 @@ public open class PreviewLabHtmlRenderer(context: DokkaContext) : HtmlRenderer(c
     private fun FlowContent.renderPreviewLabIframe(code: ContentCodeBlock) {
         val rawPayload = (code.children.singleOrNull() as? ContentText)?.text.orEmpty()
         val payload = PreviewLabTagPayload.parse(rawPayload) ?: return
-        val baseUrl = System.getProperty(PreviewLabBaseUrlProperty, PreviewLabDefaultBaseUrl)
-        val src = "$baseUrl/?iframe&previewId=${payload.previewId}"
+        val baseUrl = resolveBaseUrl()
+        val encodedPreviewId = URLEncoder.encode(payload.previewId, Charsets.UTF_8)
+        val src = "$baseUrl/?iframe&previewId=$encodedPreviewId"
 
         // Default sizing keeps a fixed 720px height (enough for the full PreviewLab UI on a
         // typical doc-site column width without making the canvas Compose wasm allocates
@@ -83,6 +92,16 @@ public open class PreviewLabHtmlRenderer(context: DokkaContext) : HtmlRenderer(c
                 attributes["allow"] = "clipboard-read; clipboard-write"
             }
         }
+    }
+
+    // Normalises the configured base URL so it composes cleanly with `"/?iframe&..."`.
+    // - blank / unset → default
+    // - trims surrounding whitespace
+    // - strips trailing `/` so we never emit `//?...`
+    private fun resolveBaseUrl(): String {
+        val raw = System.getProperty(PreviewLabBaseUrlProperty)?.trim().orEmpty()
+        val normalised = raw.ifEmpty { PreviewLabDefaultBaseUrl }
+        return normalised.trimEnd('/')
     }
 
     // Mirrors the default HtmlRenderer fallback for non-iframe code blocks; we cannot call

--- a/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/PreviewLabTagContentProvider.kt
+++ b/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/PreviewLabTagContentProvider.kt
@@ -17,11 +17,13 @@ internal object PreviewLabTagContentProvider : CustomTagContentProvider {
         sourceSet: DokkaConfiguration.DokkaSourceSet,
         customTag: CustomTagWrapper,
     ) {
-        val previewId = customTag.extractPreviewId() ?: return
-        codeBlock(language = PreviewLabIframeCode) { text(previewId) }
+        val payload = customTag.extractPayload() ?: return
+        codeBlock(language = PreviewLabIframeCode) { text(payload) }
     }
 
-    private fun CustomTagWrapper.extractPreviewId(): String? {
+    // Returns the entire trimmed tag body. The renderer is responsible for splitting it into
+    // `previewId` and optional size token (`WxH`).
+    private fun CustomTagWrapper.extractPayload(): String? {
         val firstParagraph = root.children.firstOrNull() as? P ?: return null
         val firstText = firstParagraph.children.firstOrNull() as? Text ?: return null
         return firstText.body.trim().takeIf { it.isNotEmpty() }

--- a/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/PreviewLabTagContentProvider.kt
+++ b/dokka-plugin/src/main/kotlin/me/tbsten/compose/preview/lab/dokka/PreviewLabTagContentProvider.kt
@@ -1,0 +1,29 @@
+package me.tbsten.compose.preview.lab.dokka
+
+import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.base.transformers.pages.tags.CustomTagContentProvider
+import org.jetbrains.dokka.base.translators.documentables.PageContentBuilder.DocumentableContentBuilder
+import org.jetbrains.dokka.model.doc.CustomTagWrapper
+import org.jetbrains.dokka.model.doc.P
+import org.jetbrains.dokka.model.doc.Text
+
+internal const val PreviewLabTag: String = "previewLab"
+internal const val PreviewLabIframeCode: String = "@previewLab/iframe"
+
+internal object PreviewLabTagContentProvider : CustomTagContentProvider {
+    override fun isApplicable(customTag: CustomTagWrapper): Boolean = customTag.name == PreviewLabTag
+
+    override fun DocumentableContentBuilder.contentForDescription(
+        sourceSet: DokkaConfiguration.DokkaSourceSet,
+        customTag: CustomTagWrapper,
+    ) {
+        val previewId = customTag.extractPreviewId() ?: return
+        codeBlock(language = PreviewLabIframeCode) { text(previewId) }
+    }
+
+    private fun CustomTagWrapper.extractPreviewId(): String? {
+        val firstParagraph = root.children.firstOrNull() as? P ?: return null
+        val firstText = firstParagraph.children.firstOrNull() as? Text ?: return null
+        return firstText.body.trim().takeIf { it.isNotEmpty() }
+    }
+}

--- a/dokka-plugin/src/main/resources/META-INF/services/org.jetbrains.dokka.plugability.DokkaPlugin
+++ b/dokka-plugin/src/main/resources/META-INF/services/org.jetbrains.dokka.plugability.DokkaPlugin
@@ -1,0 +1,1 @@
+me.tbsten.compose.preview.lab.dokka.ComposePreviewLabDokkaPlugin

--- a/dokka-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/dokka/ComposePreviewLabDokkaPluginTest.kt
+++ b/dokka-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/dokka/ComposePreviewLabDokkaPluginTest.kt
@@ -1,0 +1,148 @@
+package me.tbsten.compose.preview.lab.dokka
+
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldEndWith
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jsoup.Jsoup
+import org.junit.jupiter.api.Test
+import utils.TestOutputWriterPlugin
+
+class ComposePreviewLabDokkaPluginTest : BaseAbstractTest() {
+    private val configuration = dokkaConfiguration {
+        sourceSets {
+            sourceSet {
+                sourceRoots = listOf("src/main/kotlin")
+            }
+        }
+    }
+
+    @Test
+    fun `previewLab tag is rendered as iframe with previewId in src`() {
+        val writerPlugin = TestOutputWriterPlugin()
+        val source = """
+            |/src/main/kotlin/test/Test.kt
+            |package example
+            |
+            |/**
+            | * Function with previewLab tag.
+            | * @previewLab MyPreview_FooId
+            | */
+            |fun withPreviewLab(): String = "yes"
+        """.trimIndent()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin, ComposePreviewLabDokkaPlugin()),
+        ) {
+            renderingStage = { _, _ ->
+                val html = writerPlugin.writer.contents.getValue("root/example/with-preview-lab.html")
+                val doc = Jsoup.parse(html)
+                val iframes = doc.select("iframe.preview-lab-embedded")
+
+                iframes.size shouldBe 1
+                val src = iframes.first()!!.attr("src")
+                src shouldContain "?iframe&previewId=MyPreview_FooId"
+                src shouldEndWith "previewId=MyPreview_FooId"
+
+                val container = doc.select("div.preview-lab-embedded-container")
+                container.size shouldBe 1
+            }
+        }
+    }
+
+    @Test
+    fun `function without previewLab tag does not produce an iframe`() {
+        val writerPlugin = TestOutputWriterPlugin()
+        val source = """
+            |/src/main/kotlin/test/Test.kt
+            |package example
+            |
+            |/**
+            | * Plain function without any tags.
+            | */
+            |fun plain(): String = "plain"
+        """.trimIndent()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin, ComposePreviewLabDokkaPlugin()),
+        ) {
+            renderingStage = { _, _ ->
+                val html = writerPlugin.writer.contents.getValue("root/example/plain.html")
+                val doc = Jsoup.parse(html)
+                doc.select("iframe").shouldHaveSize(0)
+                doc.select("div.preview-lab-embedded-container").shouldHaveSize(0)
+            }
+        }
+    }
+
+    @Test
+    fun `previewLab base URL can be overridden via system property`() {
+        val writerPlugin = TestOutputWriterPlugin()
+        val source = """
+            |/src/main/kotlin/test/Test.kt
+            |package example
+            |
+            |/**
+            | * @previewLab AnotherPreview
+            | */
+            |fun withOverride(): String = "x"
+        """.trimIndent()
+
+        val previousValue = System.getProperty(PreviewLabBaseUrlProperty)
+        System.setProperty(PreviewLabBaseUrlProperty, "https://example.com/lab")
+        try {
+            testInline(
+                source,
+                configuration,
+                pluginOverrides = listOf(writerPlugin, ComposePreviewLabDokkaPlugin()),
+            ) {
+                renderingStage = { _, _ ->
+                    val html = writerPlugin.writer.contents.getValue("root/example/with-override.html")
+                    val src = Jsoup.parse(html).select("iframe.preview-lab-embedded").first()!!.attr("src")
+                    src shouldBe "https://example.com/lab/?iframe&previewId=AnotherPreview"
+                }
+            }
+        } finally {
+            if (previousValue == null) {
+                System.clearProperty(PreviewLabBaseUrlProperty)
+            } else {
+                System.setProperty(PreviewLabBaseUrlProperty, previousValue)
+            }
+        }
+    }
+
+    @Test
+    fun `regular kotlin code blocks are still rendered as sample-container`() {
+        val writerPlugin = TestOutputWriterPlugin()
+        val source = """
+            |/src/main/kotlin/test/Test.kt
+            |package example
+            |
+            |/**
+            | * Function whose KDoc includes a plain kotlin code sample:
+            | * ```
+            | * val x = 1
+            | * ```
+            | */
+            |fun withCodeSample(): String = "k"
+        """.trimIndent()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin, ComposePreviewLabDokkaPlugin()),
+        ) {
+            renderingStage = { _, _ ->
+                val html = writerPlugin.writer.contents.getValue("root/example/with-code-sample.html")
+                val doc = Jsoup.parse(html)
+                doc.select("iframe.preview-lab-embedded").shouldHaveSize(0)
+                doc.select("div.sample-container").size shouldBe 1
+            }
+        }
+    }
+}

--- a/dokka-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/dokka/ComposePreviewLabDokkaPluginTest.kt
+++ b/dokka-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/dokka/ComposePreviewLabDokkaPluginTest.kt
@@ -4,6 +4,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldEndWith
+import io.kotest.matchers.string.shouldNotContain
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
 import org.jsoup.Jsoup
 import org.junit.jupiter.api.Test
@@ -116,6 +117,92 @@ class ComposePreviewLabDokkaPluginTest : BaseAbstractTest() {
                 System.clearProperty(PreviewLabBaseUrlProperty)
             } else {
                 System.setProperty(PreviewLabBaseUrlProperty, previousValue)
+            }
+        }
+    }
+
+    @Test
+    fun `previewLab tag without size keeps the default fixed-height style`() {
+        val writerPlugin = TestOutputWriterPlugin()
+        val source = """
+            |/src/main/kotlin/test/Test.kt
+            |package example
+            |
+            |/**
+            | * @previewLab DefaultSized
+            | */
+            |fun defaultSized(): String = "x"
+        """.trimIndent()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin, ComposePreviewLabDokkaPlugin()),
+        ) {
+            renderingStage = { _, _ ->
+                val html = writerPlugin.writer.contents.getValue("root/example/default-sized.html")
+                val style = Jsoup.parse(html).select("iframe.preview-lab-embedded").first()!!.attr("style")
+                style shouldContain "height: 720px"
+                style shouldNotContain "aspect-ratio"
+            }
+        }
+    }
+
+    @Test
+    fun `previewLab tag with WxH suffix emits aspect-ratio instead of fixed height`() {
+        val writerPlugin = TestOutputWriterPlugin()
+        val source = """
+            |/src/main/kotlin/test/Test.kt
+            |package example
+            |
+            |/**
+            | * @previewLab Custom 1280x980
+            | */
+            |fun custom(): String = "x"
+        """.trimIndent()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin, ComposePreviewLabDokkaPlugin()),
+        ) {
+            renderingStage = { _, _ ->
+                val html = writerPlugin.writer.contents.getValue("root/example/custom.html")
+                val iframe = Jsoup.parse(html).select("iframe.preview-lab-embedded").first()!!
+                val style = iframe.attr("style")
+                style shouldContain "aspect-ratio: 1280 / 980"
+                style shouldContain "height: auto"
+                style shouldNotContain "720px"
+
+                // previewId itself must not include the size token.
+                iframe.attr("src") shouldEndWith "previewId=Custom"
+            }
+        }
+    }
+
+    @Test
+    fun `previewLab tag with malformed size token falls back to default sizing`() {
+        val writerPlugin = TestOutputWriterPlugin()
+        val source = """
+            |/src/main/kotlin/test/Test.kt
+            |package example
+            |
+            |/**
+            | * @previewLab Foo not-a-size
+            | */
+            |fun malformed(): String = "x"
+        """.trimIndent()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin, ComposePreviewLabDokkaPlugin()),
+        ) {
+            renderingStage = { _, _ ->
+                val html = writerPlugin.writer.contents.getValue("root/example/malformed.html")
+                val iframe = Jsoup.parse(html).select("iframe.preview-lab-embedded").first()!!
+                iframe.attr("style") shouldContain "height: 720px"
+                iframe.attr("src") shouldEndWith "previewId=Foo"
             }
         }
     }

--- a/dokka-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/dokka/ComposePreviewLabDokkaPluginTest.kt
+++ b/dokka-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/dokka/ComposePreviewLabDokkaPluginTest.kt
@@ -208,6 +208,163 @@ class ComposePreviewLabDokkaPluginTest : BaseAbstractTest() {
     }
 
     @Test
+    fun `previewLab tag rejects non-positive WxH and falls back to default sizing`() {
+        val writerPlugin = TestOutputWriterPlugin()
+        val source = """
+            |/src/main/kotlin/test/Test.kt
+            |package example
+            |
+            |/**
+            | * @previewLab ZeroSized 0x0
+            | */
+            |fun zeroSized(): String = "x"
+        """.trimIndent()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin, ComposePreviewLabDokkaPlugin()),
+        ) {
+            renderingStage = { _, _ ->
+                val html = writerPlugin.writer.contents.getValue("root/example/zero-sized.html")
+                val iframe = Jsoup.parse(html).select("iframe.preview-lab-embedded").first()!!
+                iframe.attr("style") shouldContain "height: 720px"
+                iframe.attr("style") shouldNotContain "aspect-ratio"
+            }
+        }
+    }
+
+    @Test
+    fun `previewLab tag falls back to default when WxH overflows Int range`() {
+        val writerPlugin = TestOutputWriterPlugin()
+        val source = """
+            |/src/main/kotlin/test/Test.kt
+            |package example
+            |
+            |/**
+            | * @previewLab Huge 999999999999x1
+            | */
+            |fun huge(): String = "x"
+        """.trimIndent()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin, ComposePreviewLabDokkaPlugin()),
+        ) {
+            renderingStage = { _, _ ->
+                val html = writerPlugin.writer.contents.getValue("root/example/huge.html")
+                val iframe = Jsoup.parse(html).select("iframe.preview-lab-embedded").first()!!
+                iframe.attr("style") shouldContain "height: 720px"
+                iframe.attr("style") shouldNotContain "aspect-ratio"
+            }
+        }
+    }
+
+    @Test
+    fun `previewId is URL-encoded when constructing the iframe src`() {
+        val writerPlugin = TestOutputWriterPlugin()
+        // `=` survives Dokka's KDoc parser (it is not a tag separator) but has URL-reserved
+        // meaning in the query string. URLEncoder turns it into `%3D`. Pre-fix this would
+        // have leaked verbatim as `previewId=a=b`, breaking query-string parsing on the
+        // gallery side.
+        val source = """
+            |/src/main/kotlin/test/Test.kt
+            |package example
+            |
+            |/**
+            | * @previewLab a=b
+            | */
+            |fun encoded(): String = "x"
+        """.trimIndent()
+
+        testInline(
+            source,
+            configuration,
+            pluginOverrides = listOf(writerPlugin, ComposePreviewLabDokkaPlugin()),
+        ) {
+            renderingStage = { _, _ ->
+                val html = writerPlugin.writer.contents.getValue("root/example/encoded.html")
+                val src = Jsoup.parse(html).select("iframe.preview-lab-embedded").first()!!.attr("src")
+                src shouldEndWith "previewId=a%3Db"
+                src shouldNotContain "previewId=a=b"
+            }
+        }
+    }
+
+    @Test
+    fun `trailing slash and surrounding whitespace in baseUrl are normalised`() {
+        val writerPlugin = TestOutputWriterPlugin()
+        val source = """
+            |/src/main/kotlin/test/Test.kt
+            |package example
+            |
+            |/**
+            | * @previewLab Foo
+            | */
+            |fun normalised(): String = "x"
+        """.trimIndent()
+
+        val previousValue = System.getProperty(PreviewLabBaseUrlProperty)
+        System.setProperty(PreviewLabBaseUrlProperty, "  https://example.com/lab/  ")
+        try {
+            testInline(
+                source,
+                configuration,
+                pluginOverrides = listOf(writerPlugin, ComposePreviewLabDokkaPlugin()),
+            ) {
+                renderingStage = { _, _ ->
+                    val html = writerPlugin.writer.contents.getValue("root/example/normalised.html")
+                    val src = Jsoup.parse(html).select("iframe.preview-lab-embedded").first()!!.attr("src")
+                    src shouldBe "https://example.com/lab/?iframe&previewId=Foo"
+                }
+            }
+        } finally {
+            if (previousValue == null) {
+                System.clearProperty(PreviewLabBaseUrlProperty)
+            } else {
+                System.setProperty(PreviewLabBaseUrlProperty, previousValue)
+            }
+        }
+    }
+
+    @Test
+    fun `blank baseUrl property falls back to the default value`() {
+        val writerPlugin = TestOutputWriterPlugin()
+        val source = """
+            |/src/main/kotlin/test/Test.kt
+            |package example
+            |
+            |/**
+            | * @previewLab Foo
+            | */
+            |fun blank(): String = "x"
+        """.trimIndent()
+
+        val previousValue = System.getProperty(PreviewLabBaseUrlProperty)
+        System.setProperty(PreviewLabBaseUrlProperty, "   ")
+        try {
+            testInline(
+                source,
+                configuration,
+                pluginOverrides = listOf(writerPlugin, ComposePreviewLabDokkaPlugin()),
+            ) {
+                renderingStage = { _, _ ->
+                    val html = writerPlugin.writer.contents.getValue("root/example/blank.html")
+                    val src = Jsoup.parse(html).select("iframe.preview-lab-embedded").first()!!.attr("src")
+                    src shouldBe "$PreviewLabDefaultBaseUrl/?iframe&previewId=Foo"
+                }
+            }
+        } finally {
+            if (previousValue == null) {
+                System.clearProperty(PreviewLabBaseUrlProperty)
+            } else {
+                System.setProperty(PreviewLabBaseUrlProperty, previousValue)
+            }
+        }
+    }
+
+    @Test
     fun `regular kotlin code blocks are still rendered as sample-container`() {
         val writerPlugin = TestOutputWriterPlugin()
         val source = """

--- a/dokka-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/dokka/ComposePreviewLabDokkaPluginTest.kt
+++ b/dokka-plugin/src/test/kotlin/me/tbsten/compose/preview/lab/dokka/ComposePreviewLabDokkaPluginTest.kt
@@ -80,8 +80,12 @@ class ComposePreviewLabDokkaPluginTest : BaseAbstractTest() {
         }
     }
 
+    // NOTE: `BaseAbstractTest` runs Dokka in-process so System property
+    // is visible to the renderer. In real Gradle builds the Dokka worker is
+    // a forked JVM (ProcessIsolation) and the property does NOT reach the
+    // renderer. See the KNOWN LIMITATION comment in PreviewLabHtmlRenderer.kt.
     @Test
-    fun `previewLab base URL can be overridden via system property`() {
+    fun `previewLab base URL can be overridden via system property (in-process only)`() {
         val writerPlugin = TestOutputWriterPlugin()
         val source = """
             |/src/main/kotlin/test/Test.kt

--- a/dokkaDocs/build.gradle.kts
+++ b/dokkaDocs/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
     dokka(projects.previewLab)
     dokka(projects.ui)
     dokka(projects.annotation)
+
+    dokkaPlugin(projects.dokkaPlugin)
 }
 
 dokka {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,10 @@ filekit = "0.12.0"
 # Test
 kotest = "6.0.5"
 kctfork = "0.12.1"
+jsoup = "1.18.3"
+
+# Dokka Plugin
+kotlinxHtml = "0.11.0"
 
 # IntelliJ Plugin
 intellijPlatform = "2.6.0"
@@ -109,6 +113,14 @@ kotlinCompilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embe
 ktlintGradlePlugin = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref = "ktlintGradle" }
 vanniktechMavenPublishGradlePlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "vanniktechMavenPublish" }
 dokkaGradlePlugin = { module = "org.jetbrains.dokka:org.jetbrains.dokka.gradle.plugin", version.ref = "dokka" }
+dokkaCore = { module = "org.jetbrains.dokka:dokka-core", version.ref = "dokka" }
+dokkaBase = { module = "org.jetbrains.dokka:dokka-base", version.ref = "dokka" }
+dokkaTestApi = { module = "org.jetbrains.dokka:dokka-test-api", version.ref = "dokka" }
+dokkaBaseTestUtils = { module = "org.jetbrains.dokka:dokka-base-test-utils", version.ref = "dokka" }
+dokkaAnalysisKotlinSymbols = { module = "org.jetbrains.dokka:analysis-kotlin-symbols", version.ref = "dokka" }
+kotlinxHtml = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version.ref = "kotlinxHtml" }
+jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
+junitJupiter = { module = "org.junit.jupiter:junit-jupiter", version = "5.10.2" }
 androidGradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 composeGradlePlugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose" }
 hotReloadGradlePlugin = { module = "org.jetbrains.compose.hot-reload:org.jetbrains.compose.hot-reload.gradle.plugin", version.ref = "hotReload" }

--- a/integrationTest/build.gradle.kts
+++ b/integrationTest/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.hotReload).apply(false)
     id("me.tbsten.compose.preview.lab").apply(false)
     alias(libs.plugins.binaryCompatibilityValidator)
+    alias(libs.plugins.dokka).apply(false)
 }
 
 apiValidation {

--- a/integrationTest/uiLib/build.gradle.kts
+++ b/integrationTest/uiLib/build.gradle.kts
@@ -6,6 +6,17 @@ plugins {
     id("me.tbsten.compose.preview.lab")
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
+    alias(libs.plugins.dokka)
+}
+
+dependencies {
+    // Compose Preview Lab dokka plugin: embeds @previewLab <previewId> tags as <iframe>s
+    // pointing at the hosted Compose Preview Lab gallery.
+    // Resolved via the composite build (`includeBuild("../")`) — no mavenLocal needed
+    // when running from this repo. External projects should depend on the published
+    // coordinate `me.tbsten.compose.preview.lab:dokka-plugin:<version>` and add
+    // `mavenLocal()` (or Maven Central once published).
+    dokkaPlugin("me.tbsten.compose.preview.lab:dokka-plugin:${libs.versions.composePreviewLab.get()}")
 }
 
 kotlin {

--- a/integrationTest/uiLib/src/commonMain/kotlin/me/tbsten/compose/preview/lab/sample/lib/MyButton.kt
+++ b/integrationTest/uiLib/src/commonMain/kotlin/me/tbsten/compose/preview/lab/sample/lib/MyButton.kt
@@ -12,6 +12,15 @@ import me.tbsten.compose.preview.lab.field.StringField
 import me.tbsten.compose.preview.lab.gallery.LocalPreviewLabGalleryNavigator
 import me.tbsten.compose.preview.lab.gallery.navigateOr
 
+/**
+ * A small wrapper around Material 3 [Button] that drives a label and tap handler.
+ *
+ * @param text Button label.
+ * @param onClick Invoked when the user taps the button.
+ * @param modifier Optional modifier applied to the underlying [Button].
+ *
+ * @previewLab MyButtonPreview
+ */
 @Composable
 fun MyButton(text: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
     Button(onClick = onClick, modifier = modifier) {

--- a/integrationTest/uiLib/src/commonMain/kotlin/me/tbsten/compose/preview/lab/sample/lib/MyButton.kt
+++ b/integrationTest/uiLib/src/commonMain/kotlin/me/tbsten/compose/preview/lab/sample/lib/MyButton.kt
@@ -19,7 +19,7 @@ import me.tbsten.compose.preview.lab.gallery.navigateOr
  * @param onClick Invoked when the user taps the button.
  * @param modifier Optional modifier applied to the underlying [Button].
  *
- * @previewLab MyButtonPreview
+ * @previewLab MyButtonPreview 1280x680
  */
 @Composable
 fun MyButton(text: String, onClick: () -> Unit, modifier: Modifier = Modifier) {

--- a/integrationTest/uiLib/src/commonMain/kotlin/me/tbsten/compose/preview/lab/sample/lib/MyTextField.kt
+++ b/integrationTest/uiLib/src/commonMain/kotlin/me/tbsten/compose/preview/lab/sample/lib/MyTextField.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.tooling.preview.Preview
  * @param onValueChange Called with the new value on every edit.
  * @param modifier Optional modifier applied to the underlying [TextField].
  *
- * @previewLab MyTextFieldPreview 1280x980
+ * @previewLab MyTextFieldPreview 1280x680
  */
 @Composable
 fun MyTextField(value: String, onValueChange: (String) -> Unit, modifier: Modifier = Modifier) {

--- a/integrationTest/uiLib/src/commonMain/kotlin/me/tbsten/compose/preview/lab/sample/lib/MyTextField.kt
+++ b/integrationTest/uiLib/src/commonMain/kotlin/me/tbsten/compose/preview/lab/sample/lib/MyTextField.kt
@@ -13,6 +13,16 @@ import me.tbsten.compose.preview.lab.event.ChangeEvent
 import me.tbsten.compose.preview.lab.field.StringField
 import androidx.compose.ui.tooling.preview.Preview
 
+/**
+ * A thin wrapper around Material 3 [TextField] with the stateful preview demo
+ * available in the gallery.
+ *
+ * @param value Current text.
+ * @param onValueChange Called with the new value on every edit.
+ * @param modifier Optional modifier applied to the underlying [TextField].
+ *
+ * @previewLab MyTextFieldPreview
+ */
 @Composable
 fun MyTextField(value: String, onValueChange: (String) -> Unit, modifier: Modifier = Modifier) {
     TextField(

--- a/integrationTest/uiLib/src/commonMain/kotlin/me/tbsten/compose/preview/lab/sample/lib/MyTextField.kt
+++ b/integrationTest/uiLib/src/commonMain/kotlin/me/tbsten/compose/preview/lab/sample/lib/MyTextField.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.tooling.preview.Preview
  * @param onValueChange Called with the new value on every edit.
  * @param modifier Optional modifier applied to the underlying [TextField].
  *
- * @previewLab MyTextFieldPreview
+ * @previewLab MyTextFieldPreview 1280x980
  */
 @Composable
 fun MyTextField(value: String, onValueChange: (String) -> Unit, modifier: Modifier = Modifier) {

--- a/preview-lab/src/commonMain/kotlin/me/tbsten/compose/preview/lab/previewlab/PreviewLab.kt
+++ b/preview-lab/src/commonMain/kotlin/me/tbsten/compose/preview/lab/previewlab/PreviewLab.kt
@@ -280,8 +280,6 @@ import me.tbsten.compose.preview.lab.ui.components.toast.rememberToastHostState
  * @see PreviewLabState State management and persistence
  * @see PreviewLabScope Scope providing field and event functions
  * @see ScreenSize Device screen size definitions and presets
- *
- * @previewLab samplePreviewId
  */
 @Composable
 fun PreviewLab(

--- a/preview-lab/src/commonMain/kotlin/me/tbsten/compose/preview/lab/previewlab/PreviewLab.kt
+++ b/preview-lab/src/commonMain/kotlin/me/tbsten/compose/preview/lab/previewlab/PreviewLab.kt
@@ -280,6 +280,8 @@ import me.tbsten.compose.preview.lab.ui.components.toast.rememberToastHostState
  * @see PreviewLabState State management and persistence
  * @see PreviewLabScope Scope providing field and event functions
  * @see ScreenSize Device screen size definitions and presets
+ *
+ * @previewLab samplePreviewId
  */
 @Composable
 fun PreviewLab(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -61,6 +61,7 @@ include(":compiler-plugin:compat-k2320")
 include(":compiler-plugin:compat-k2321")
 include(":compiler-plugin:compat-k240_beta2")
 include(":gradle-plugin")
+include(":dokka-plugin")
 include(":dokkaDocs")
 
 include(":extension:kotlinx-datetime", projectName = "extension-kotlinx-datetime")


### PR DESCRIPTION
issue #96 への試作 PR。`@previewLab <previewId>` という KDoc タグを書くだけで、Dokka が生成する HTML に PreviewLab の Preview を `<iframe>` として埋め込めるようになる。

参考: [Kotlin/Storytale `modules/dokka-plugin`](https://github.com/Kotlin/Storytale/tree/main/modules/dokka-plugin)。同じ拡張点（`CustomTagContentProvider` + `HtmlRenderer` の差し替え + SPI 登録）を `@story` ではなく `@previewLab` 用に焼き直した実装。

---

## ユーザ目線: 使い方

### 1. KDoc に書く

```kotlin
/**
 * 押すと変色するボタン。
 *
 * @param onClick タップハンドラ
 * @previewLab MyButton_DemoPreview
 * // ↑ もしくはアスペクト比を指定:
 * // @previewLab MyButton_DemoPreview 1280x680
 */
@Composable
fun MyButton(onClick: () -> Unit) { /* … */ }
```

タグ書式: `@previewLab <previewId> [WxH]`

| 書き方 | 出力 |
|---|---|
| `@previewLab MyButtonPreview` | `width: calc(100% - 32px); height: 720px;` 固定 |
| `@previewLab MyButtonPreview 1280x680` | `width: calc(100% - 32px); aspect-ratio: 1280 / 680; height: auto;` |
| `@previewLab Foo not-a-size` | サイズ token は無視してデフォルトにフォールバック |

- 区切りは whitespace、`x` は **lowercase のみ**、`\d+x\d+` のみ受け付け
- `previewId` には size token が混入しない
- 全 iframe 共通で `border: 2px solid #d0d7de` (GitHub 風 neutral gray) と `margin: 16px` (上下左右) を付与

### 2. 自分のプロジェクトに Dokka plugin を入れる

ライブラリを使う側のプロジェクト（KDoc を生成するプロジェクト）の `build.gradle.kts`:

```kotlin
plugins {
    id("org.jetbrains.dokka") version "2.1.0"
}

dependencies {
    dokkaPlugin("me.tbsten.compose.preview.lab:dokka-plugin:<version>")
}
```

`<version>` は `compose-preview-lab` 本体と同じバージョン（現状 `0.1.0-dev13`）。Maven Central 公開はまだなので、PR の **試作段階** では `publishToMavenLocal` 経由で取得して動作確認できる:

```bash
./gradlew :dokka-plugin:publishToMavenLocal
# その後 consumer 側で
./gradlew dokkaGenerate
```

### 3. 出力

`./gradlew dokkaGenerate` 後、`@previewLab` を持つ API のページにだけ `<iframe>` が出る:

```html
<div class="preview-lab-embedded-container">
  <iframe class="preview-lab-embedded"
          src="compose-preview-lab-gallery/?iframe & previewId=MyButton_DemoPreview"
          loading="lazy"
          allow="clipboard-read; clipboard-write"
          style="display: block; width: calc(100% - 32px); aspect-ratio: 1280 / 680; height: auto; border: 2px solid #d0d7de; margin: 16px; ">
  </iframe>
</div>
```

`src` の相対パスは **Dokka HTML を置くサイト上の `compose-preview-lab-gallery/` ディレクトリに PreviewLab の gallery サイトをホストする** ことが前提（PR #98 の `?iframe&previewId=...` URL 規約に乗っている）。
たとえば GitHub Pages なら、`/docs/dokka/` に Dokka HTML を、`/docs/dokka/.../compose-preview-lab-gallery/` に gallery の wasmJs バンドルを並べて配置するだけで、iframe からの相対参照が解決される。

---

## このリポジトリで試す（integrationTest）

`integrationTest/uiLib` に既に配線済み（試作確認用）。手順:

```bash
# 1. uiLib の dokka を生成
(cd integrationTest && ./gradlew :uiLib:dokkaGenerate)

# 2. gallery 本体を併設（PreviewLab UI を iframe 内で動かしたいとき）
(cd integrationTest && ./gradlew :app:wasmJsBrowserDistribution)
UI_DIR=integrationTest/uiLib/build/dokka/html/ui-lib/me.tbsten.compose.preview.lab.sample.lib
cp -r integrationTest/app/build/dist/wasmJs/productionExecutable "$UI_DIR/compose-preview-lab-gallery"

# 3. 配信
(cd integrationTest/uiLib/build/dokka/html && python3 -m http.server 8000)
```

開く:
- <http://localhost:8000/ui-lib/me.tbsten.compose.preview.lab.sample.lib/-my-button.html> — `@previewLab MyButtonPreview 1280x680`
- <http://localhost:8000/ui-lib/me.tbsten.compose.preview.lab.sample.lib/-my-text-field.html> — `@previewLab MyTextFieldPreview 1280x680`

composite build (`includeBuild("../")`) のおかげで dokka-plugin の dependency は自動で included build の `:dokka-plugin` に置き換わるため `publishToMavenLocal` は不要。

---

## カスタマイズできること（現状）

| 項目                 | やり方                                                            | 試作時点での状態 |
|----------------------|---------------------------------------------------------------------|---------------|
| タグの引数 (previewId) | KDoc に `@previewLab <previewId>` を書く                            | ✅ 動く |
| アスペクト比          | KDoc に `@previewLab <previewId> <W>x<H>` を書く（lowercase `x`、正整数のみ） | ✅ 動く |
| iframe の枠線         | デフォルトで `border: 2px solid #d0d7de`                            | ✅ 動く（CSS 上書きで変更可） |
| iframe の余白         | デフォルトで `margin: 16px`、`width: calc(100% - 32px)` で overflow 防止 | ✅ 動く |
| ベース URL            | `System.getProperty("previewLab.dokka.baseUrl")` で上書き         | ⚠️ in-process 限定（後述） |
| iframe のスタイル     | `iframe.preview-lab-embedded` / `.preview-lab-embedded-container` を CSS で上書き可 | ✅ 動く |

### ベース URL 上書きの **既知の制限**

`-DpreviewLab.dokka.baseUrl=https://example.com/lab` を Gradle に渡しても、Dokka v2 のジェネレータが**別 JVM ワーカー** (`ProcessIsolation`) で走るので System property がレンダラに届かない。`gradle.properties` の `systemProp.` 経由でも同じく届かない。

→ Playwright 検証で確認済み（PR 内 commit `docs(dokka-plugin): note that System property override only works in-process` 参照）。

実プロジェクトで上書きしたい場合は試作の現バージョンでは未対応。**次の Iteration で `DokkaPluginParametersBaseSpec` ベースの公式 plugin configuration に置き換える**:

```kotlin
// 将来形（未実装）
dokka {
    pluginsConfiguration {
        composePreviewLab {
            baseUrl.set("https://my-site.example.com/gallery")
        }
    }
}
```

---

## 試作のため未対応 / 別タスク化したい項目

- `baseUrl` を `DokkaPluginParametersBaseSpec` / `ConfigurableBlock` ベースの公式 plugin configuration に置き換える（最優先）
- iframe スタイル (border / margin / color) のテーマカスタマイズ DSL
- README / docs サイトに利用方法を記載
- compiler-plugin が生成する `previewId` フォーマットと KDoc 上で書く ID を揃える運用ガイド
- Maven Central 公開タイミングの判断（PR では maven local までで停止）
- `PreviewLab` Composable の KDoc にある `@previewLab samplePreviewId` は **placeholder**。実 previewId への差し替え or 取り消しが必要

---

## 動作確認した内容

### 内部メカニズム

- KDoc 内の `@previewLab <previewId> [WxH]` を `CustomTagContentProvider` で受け取り、本文を丸ごと `@previewLab/iframe` という仮想言語の `ContentCodeBlock` に渡す
- `HtmlRenderer` を差し替え、`code.language == "@previewLab/iframe"` の codeBlock 本文をパース (`PreviewLabTagPayload.parse`) して previewId + 任意のアスペクト比を取り出し `<iframe>` を出力
- それ以外は default の sample-container 描画（`super.buildCodeBlock(...)` を呼べない Kotlin の制約のため Storytale 同様 default 実装を inline コピー）

### ユニットテスト (`./gradlew :dokka-plugin:test`) — 全 7 件 pass

- [x] `@previewLab fooId` → 生成 HTML に `<iframe class="preview-lab-embedded" src="...previewId=fooId">` が現れる
- [x] タグなしの API ページには iframe / container が出ない
- [x] baseUrl の System property override が（in-process 経路で）効く
- [x] サイズ未指定で `height: 720px` 固定スタイルになる
- [x] `@previewLab Custom 1280x980` で `aspect-ratio: 1280 / 980; height: auto` が出る（previewId に size token が混入しない）
- [x] 不正な size token (`not-a-size`) は無視されてデフォルトサイズにフォールバック
- [x] 通常 Kotlin code block は `div.sample-container` のまま regression なし

### dokkaDocs 統合（このリポジトリ）

- [x] `./gradlew :dokkaDocs:dokkaGenerate --warning-mode all` 成功
- [x] `dokkaDocs/build/dokka/html/preview-lab/.../-preview-lab.html` だけに iframe（`previewId=samplePreviewId`）が出ている
- [x] 他の API ページに iframe / container は出ていない

### integrationTest 統合

- [x] `(cd integrationTest && ./gradlew :uiLib:dokkaGenerate)` 成功
- [x] `MyButton` / `MyTextField` の API ページに正しい previewId (`MyButtonPreview` / `MyTextFieldPreview`) で iframe が出る
- [x] 両方 `aspect-ratio: 1280 / 680` が style 属性に乗っている
- [x] `compose-preview-lab-gallery/` に wasmJs distribution を並べると iframe 内で実 PreviewLab UI が動く（手元の Chrome で確認済み）

### Maven Local publish + 外部 build からの消費

- [x] `./gradlew :dokka-plugin:publishToMavenLocal` 成功
- [x] `~/.m2/.../dokka-plugin-<ver>.jar` の `META-INF/services/org.jetbrains.dokka.plugability.DokkaPlugin` に `ComposePreviewLabDokkaPlugin` が登録されている
- [x] 独立した consumer Gradle プロジェクト（`.local/dokka-plugin-consumer/`）から `dokkaPlugin("me.tbsten.compose.preview.lab:dokka-plugin:0.1.0-dev13")` で依存 → `dokkaGenerate` 後の HTML に正しく iframe が出る

### Playwright での実ブラウザレンダリング検証

- [x] dokkaDocs / integrationTest 出力を `python3 -m http.server` で配信、Playwright で開く
  - iframe の DOM 属性（class / src / loading=lazy / allow / style）すべて期待通り
  - 通常 code block 11 件と iframe 1 件が共存（仮想言語クラス `lang-@previewLab` は code 要素には漏れていない）
  - Kotlin sample container は syntax highlight 付きで正常描画
- [x] consumer 出力の `sample.html` で iframe DOM 確認、`plain.html` には iframe が無いことも確認
- [x] consumer 側に `compose-preview-lab-gallery/` モックを置き、iframe が完全ロード → 子 frame の document 内で `previewId=demoSamplePreview` / `?iframe` が正しく受信されていることを `iframe.contentDocument` 経由で検証（end-to-end の URL 規約も実証）
- [x] baseUrl 上書きの worker-fork 限定問題は実 build で再現 → 上記「既知の制限」セクションに記載

### 静的検査

- [x] `./gradlew :dokka-plugin:ktlintCheck` pass
- [x] `./gradlew apiCheck` 全モジュール pass（`dokka-plugin/api/dokka-plugin.api` baseline 含む）

---

Closes #96 （上記 Open Items を別タスクで潰したあとに main merge する想定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)